### PR TITLE
Upd welcoming msg in channel at start

### DIFF
--- a/heltour/tournament/tasks.py
+++ b/heltour/tournament/tasks.py
@@ -496,8 +496,7 @@ def create_team_channel(self, team_ids):
     intro_message = textwrap.dedent("""
             Welcome! This is your private team channel. Feel free to chat, study, discuss strategy, or whatever you like!
             You need to pick a team captain and a team name by {season_start}.
-            Once you've chosen (or if you need help with anything), contact one of the moderators:
-            {mods}
+            Once you've chosen (or if you need help with anything), contact one of the moderators using the command `@chesster summon mods` in #general (do not contact them directly.)
 
             Here are some useful links for your team:
             - <{pairings_url}|View your team pairings>


### PR DESCRIPTION
I've change the welcoming message, now it ask for people to use the summon mods command of chesster instead of contacting mods directly.