### PR TITLE
Fix for issue #310 - Dark Mode standings text is unreadable in lonewolf FAQ

### DIFF
--- a/heltour/tournament/static/tournament/css/_common.scss
+++ b/heltour/tournament/static/tournament/css/_common.scss
@@ -763,27 +763,33 @@ div.inline {
     vertical-align: middle;
 }
 
-.player-gold {
+.standings-container {
+    color: black;
+}
+
+.standings-container p:first-child {
     background-color: #ffd700;
 }
 
-.player-silver {
+.standings-container p:nth-child(2) {
     background-color: #c0c0c0;
 }
 
-.player-bronze {
+.standings-container p:nth-child(3) {
     background-color: #cd7f32;
 }
 
-.player-blue {
+.standings-container p:nth-child(4) {
     background-color: #7bbcf2;
 }
-
-.player-gold a,
-.player-silver a,
-.player-bronze a,
-.player-blue a {
-    color: black;
+.standings-container p {
+    display: inline;
+    padding-left: 10px;
+    padding-right: 10px;
+}
+.standings-container p:after {
+    content: '\A';
+    white-space:pre;
 }
 
 .table-menu {

--- a/heltour/tournament/static/tournament/css/_dark_mode.scss
+++ b/heltour/tournament/static/tournament/css/_dark_mode.scss
@@ -137,20 +137,29 @@ body.dark {
         background-color: #514d67;
     }
 
-    .player-gold {
+    .standings-container p:first-child {
         background-color: #82773c;
     }
 
-    .player-silver {
+    .standings-container p:nth-child(2) {
         background-color: #7b7b7b;
     }
 
-    .player-bronze {
+    .standings-container p:nth-child(3) {
         background-color: #8a5622;
     }
 
-    .player-blue {
+    .standings-container p:nth-child(4) {
         background-color: #34546f;
+    }
+    .standings-container p {
+        display: inline;
+        padding-left: 10px;
+        padding-right: 10px;
+    }
+    .standings-container p:after {
+        content: '\A';
+        white-space:pre;
     }
 
     .legend-swatch {


### PR DESCRIPTION
Solves #310 

A half measure solution but my first contribution so a lose/win type situation.

Here's the issues I've been facing. CK Editor strips tags because security. I agree with that. Problem is attaching a custom class to any element. 

So I explored using the "div" toolbar extension which allows you to enter a div and even attach a custom css class to it. So since that's all I had I fashioned a purely CSS solution.

Please see examples of how it looks in both themes and how to implement it in the editor.

![light-theme-standings](https://user-images.githubusercontent.com/10652272/85577854-9a6bbe00-b607-11ea-9858-c156e6575003.png)
![dark-theme-standings](https://user-images.githubusercontent.com/10652272/85577867-9cce1800-b607-11ea-87e6-8c4ef70144c1.png)


This is how it would be implemented:
![wyswyg-editor-standings](https://user-images.githubusercontent.com/10652272/85577934-abb4ca80-b607-11ea-9a29-1743c98ade0e.png)
![wyswyg-source-code](https://user-images.githubusercontent.com/10652272/85577946-ad7e8e00-b607-11ea-948d-7254c0449f50.png)
