### PR TITLE
More aggressive wrapping for team names in tables

### DIFF
--- a/heltour/tournament/static/tournament/css/_common.scss
+++ b/heltour/tournament/static/tournament/css/_common.scss
@@ -130,6 +130,13 @@ div.inline {
     color: inherit;
 }
 
+table .team-link {
+    // Both lines have the same effect. `anywhere` value is not supported on
+    // safari yet. `word-break` is deprecated but still supported everyewhere.
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
 .player-profile-row {
     max-width: 1200px;
 }


### PR DESCRIPTION
Long unbreakable words in team names (e.g. a FEN string...) would either overflow or cause tables to grow too wide for narrow screens.

This CSS change just allows for breaking of normally unbreakable words in .team-links in tables.

I can't run vagrant here, and I don't have anything that can run safari, so this was just tested with the inspector in chrome and firefox. I can't imagine how this could break anything, but it might be worth the time to double check anyways before pushing to prod.

Example of the issue on an iOS device, courtesy of M0r1:
![long team name example](https://user-images.githubusercontent.com/10248419/150869805-dba632b3-a2c6-4123-a26b-1d0f0d54ee80.jpg)



