### PR TITLE
335 red card handling

### DIFF
--- a/heltour/tournament/api.py
+++ b/heltour/tournament/api.py
@@ -374,6 +374,7 @@ def set_availability(request):
     try:
         round_ = _get_next_round(league_tag, season_tag, round_num)
         player = Player.objects.filter(lichess_username__iexact=player_name).first()
+        season_player = SeasonPlayer.objects.filter(player=player, season=round_.season).first()
     except IndexError:
         return JsonResponse({'updated': 0, 'error': 'no_matching_rounds'})
 
@@ -382,6 +383,9 @@ def set_availability(request):
 
     if round_.is_completed:
         return JsonResponse({'updated': 0, 'error': 'round_over'})
+    
+    if season_player.card_color == "red":
+        return JsonResponse({'updated': 0, 'error': 'player_red_card'})
 
     PlayerAvailability.objects.update_or_create(round=round_, player=player,
                                                 defaults={'is_available': is_available})

--- a/heltour/tournament/templates/tournament/availability.html
+++ b/heltour/tournament/templates/tournament/availability.html
@@ -45,12 +45,13 @@
                                 <tr>
                                     <td>Round {{ r.number }}</td>
                                     <td>{{ r.start_date|date_or_q:'%b %-d' }} - {{ r.end_date|date_or_q:'%b %-d' }}</td>
-                                    {% for p, is_av in av_list %}
+                                    {% for p, is_av, is_red in av_list %}
                                         <td>
                                             <input type="checkbox" name="av_r{{ r.number }}_{{ p.lichess_username }}"
                                                    data-toggle="toggle" data-on="Unavailable" data-off="Available"
                                                    data-onstyle="default" data-offstyle="success" data-size="small"
                                                    {% if not is_av %}checked{% endif %}
+                                                   {% if is_red %} disabled="true" {% endif %}
                                             />
                                         </td>
                                     {% endfor %}

--- a/heltour/tournament/views.py
+++ b/heltour/tournament/views.py
@@ -1828,25 +1828,29 @@ class AvailabilityView(SeasonView, LoginRequiredMixin):
 
             availability_set = PlayerAvailability.objects.filter(player__in=player_list,
                                                                  round__in=round_list).nocache()
-            season_player_set = SeasonPlayer.objects.filter(player__in=player_list, season=self.season).nocache()
             is_available_dict = {(av.round_id, av.player_id): av.is_available for av in
                                  availability_set}
-
+            
+            season_player_set = SeasonPlayer.objects.filter(player__in=player_list, season=self.season).nocache()
+            has_red_card_dict = {sp.player : sp.card_color == "red" for sp in season_player_set}
+            
             if post:
                 for r in round_list:
                     for p in player_list:
                         field_name = 'av_r%d_%s' % (r.number, p.lichess_username)
                         is_available = self.request.POST.get(field_name) != 'on'
                         
-                        if (is_available != is_available_dict.get((r.id, p.id), True) and 
-                        SeasonPlayer.objects.filter(player=p, season=self.season).first().card_color != "red"):
+                        season_player = SeasonPlayer.objects.filter(player=p, season=self.season).first()
+                        can_update_availability = season_player is not None and season_player.card_color != 'red'
+                        
+                        if (is_available != is_available_dict.get((r.id, p.id), True) and can_update_availability):
                             PlayerAvailability.objects.update_or_create(player=p, round=r,
                                                                         defaults={
                                                                             'is_available': is_available})
                 return redirect('by_league:by_season:edit_availability', self.league.tag,
                                 self.season.tag)
 
-            round_data = [(r, [(p, is_available_dict.get((r.id, p.id), True), season_player_set.get(player=p).card_color=="red") for p in player_list])
+            round_data = [(r, [(p, is_available_dict.get((r.id, p.id), True), has_red_card_dict.get(p, False)) for p in player_list])
                           for r in round_list]
 
         context = {

--- a/heltour/tournament/workflows.py
+++ b/heltour/tournament/workflows.py
@@ -479,6 +479,9 @@ class ApproveRegistrationWorkflow():
                     sp.save()
 
         # Set availability
+        ''' weeks that are set unavailable already will not be switched back to available here. 
+            If this is ever supposed to change, it should be considered that red-carded players should not
+            be able toset themselves available by changing their registration.'''
         for week_number in reg.weeks_unavailable.split(','):
             if week_number != '':
                 round_ = Round.objects.filter(season=season, number=int(week_number)).first()


### PR DESCRIPTION
Automated handling of red cards for team league
- set player unavailable for current and remaining rounds
- Players cannot change their availability when they have a red card
- Captains connot change availability of players with red card
- However, moderators can still change the availability via the tournament admin.