### PR TITLE
fixes #450

### DIFF
--- a/heltour/tournament/api.py
+++ b/heltour/tournament/api.py
@@ -375,7 +375,6 @@ def set_availability(request):
         round_ = _get_next_round(league_tag, season_tag, round_num)
         player = Player.objects.filter(lichess_username__iexact=player_name).first()
         season_player = SeasonPlayer.objects.filter(player=player, season=round_.season).first()
-        
     except IndexError:
         return JsonResponse({'updated': 0, 'error': 'no_matching_rounds'})
 

--- a/heltour/tournament/api.py
+++ b/heltour/tournament/api.py
@@ -375,6 +375,7 @@ def set_availability(request):
         round_ = _get_next_round(league_tag, season_tag, round_num)
         player = Player.objects.filter(lichess_username__iexact=player_name).first()
         season_player = SeasonPlayer.objects.filter(player=player, season=round_.season).first()
+        
     except IndexError:
         return JsonResponse({'updated': 0, 'error': 'no_matching_rounds'})
 
@@ -386,6 +387,12 @@ def set_availability(request):
     
     if season_player.card_color == "red":
         return JsonResponse({'updated': 0, 'error': 'player_red_card'})
+    
+    if season_player.has_scheduled_game_in_round(round_):
+        return JsonResponse({'updated': 0, 'error': 'scheduled_game'})
+    
+    if has_scheduled_game:
+        return JsonResponse({'updated': 0, 'error': 'game_scheduled'})
 
     PlayerAvailability.objects.update_or_create(round=round_, player=player,
                                                 defaults={'is_available': is_available})

--- a/heltour/tournament/api.py
+++ b/heltour/tournament/api.py
@@ -235,7 +235,7 @@ def get_roster(request):
         return JsonResponse(
             {'season_tag': None, 'players': None, 'teams': None, 'error': 'no_matching_rounds'})
 
-    if season.league.competitor_type == 'team':
+    if season.league.is_team_league():
         return _team_roster(season)
     else:
         return _lone_roster(season)
@@ -389,9 +389,6 @@ def set_availability(request):
     
     if season_player.has_scheduled_game_in_round(round_):
         return JsonResponse({'updated': 0, 'error': 'scheduled_game'})
-    
-    if has_scheduled_game:
-        return JsonResponse({'updated': 0, 'error': 'game_scheduled'})
 
     PlayerAvailability.objects.update_or_create(round=round_, player=player,
                                                 defaults={'is_available': is_available})

--- a/heltour/tournament/models.py
+++ b/heltour/tournament/models.py
@@ -1801,7 +1801,29 @@ class SeasonPlayer(_BaseModel):
         for r in rounds:
             PlayerAvailability.objects.update_or_create(round=r, player=self.player,
                                                     defaults={'is_available': False})
+            
+    def has_scheduled_game_in_round(self, round):
+        scheduled_as_white = False
+        scheduled_as_black = False
+        
+        if self.season.league.competitor_type == 'team':
+            player_white_pairings = TeamPlayerPairing.objects.filter(white=self.player)
+            player_black_pairings = TeamPlayerPairing.objects.filter(black=self.player)
+        else:
+            player_white_pairings = LonePlayerPairing.objects.filter(white=self.player)
+            player_black_pairings = LonePlayerPairing.objects.filter(black=self.player)
+            
+        for pairing in player_white_pairings:
+            if int(pairing.round_number()) == int(round.number):
+                scheduled_as_white = pairing.scheduled_time is not None
+        
+        for pairing in player_black_pairings:
+            if int(pairing.round_number()) == int(round.number):
+                scheduled_as_black = pairing.scheduled_time is not None
 
+        return scheduled_as_white or scheduled_as_black
+            
+    
     def player_rating_display(self, league=None):
         if self.final_rating is not None:
             return self.final_rating

--- a/heltour/tournament/models.py
+++ b/heltour/tournament/models.py
@@ -14,6 +14,7 @@ from django.contrib.auth.models import User
 from django.contrib.postgres.fields.jsonb import JSONField
 from django.contrib.sites.models import Site
 from django_comments.models import Comment
+from django.db.models import Q
 from heltour import settings
 import reversion
 
@@ -163,6 +164,9 @@ class League(_BaseModel):
             return self.leaguesetting
         except LeagueSetting.DoesNotExist:
             return LeagueSetting.objects.create(league=self)
+        
+    def is_team_league(self):
+        return self.competitor_type == 'team'
 
     def __str__(self):
         return self.name
@@ -302,7 +306,7 @@ class Season(_BaseModel):
             # Remove out of date prizes
             SeasonPrizeWinner.objects.filter(season_prize__season=self).delete()
             # Award prizes
-            if self.league.competitor_type == 'team':
+            if self.league.is_team_league():
                 team_scores = sorted(
                     TeamScore.objects.filter(team__season=self).select_related('team').nocache(),
                     reverse=True)
@@ -326,7 +330,7 @@ class Season(_BaseModel):
                                                          player=eligible_players[prize.rank - 1])
 
     def calculate_scores(self):
-        if self.league.competitor_type == 'team':
+        if self.league.is_team_league():
             self._calculate_team_scores()
         else:
             self._calculate_lone_scores()
@@ -954,7 +958,7 @@ class PlayerLateRegistration(_BaseModel):
             self.perform_registration()
 
     def clean(self):
-        if self.round_id and self.round.season.league.competitor_type == 'team':
+        if self.round_id and self.round.season.league.is_team_league():
             raise ValidationError('Player late registrations can only be created for lone leagues')
 
     def __str__(self):
@@ -992,7 +996,7 @@ class PlayerWithdrawal(_BaseModel):
             self.perform_withdrawal()
 
     def clean(self):
-        if self.round_id and self.round.season.league.competitor_type == 'team':
+        if self.round_id and self.round.season.league.is_team_league():
             raise ValidationError('Player withdrawals can only be created for lone leagues')
 
     def __str__(self):
@@ -1070,7 +1074,7 @@ class PlayerBye(_BaseModel):
             round_.season.calculate_scores()
 
     def clean(self):
-        if self.round_id and self.round.season.league.competitor_type == 'team':
+        if self.round_id and self.round.season.league.is_team_league():
             raise ValidationError('Player byes can only be created for lone leagues')
 
 
@@ -1803,26 +1807,13 @@ class SeasonPlayer(_BaseModel):
                                                     defaults={'is_available': False})
             
     def has_scheduled_game_in_round(self, round):
-        scheduled_as_white = False
-        scheduled_as_black = False
-        
-        if self.season.league.competitor_type == 'team':
-            player_white_pairings = TeamPlayerPairing.objects.filter(white=self.player)
-            player_black_pairings = TeamPlayerPairing.objects.filter(black=self.player)
-        else:
-            player_white_pairings = LonePlayerPairing.objects.filter(white=self.player)
-            player_black_pairings = LonePlayerPairing.objects.filter(black=self.player)
+        pairingModel = TeamPlayerPairing.objects.filter(team_pairing__round=round)
+        if not self.season.league.is_team_league():
+            pairingModel = LonePlayerPlairing.objects.filter(round=round)
             
-        for pairing in player_white_pairings:
-            if int(pairing.round_number()) == int(round.number):
-                scheduled_as_white = pairing.scheduled_time is not None
-        
-        for pairing in player_black_pairings:
-            if int(pairing.round_number()) == int(round.number):
-                scheduled_as_black = pairing.scheduled_time is not None
-
-        return scheduled_as_white or scheduled_as_black
-            
+        return pairingModel.filter(
+            (Q(white=self.player) | Q(black=self.player)) & Q(scheduled_time__isnull=False)#
+          ).exists()
     
     def player_rating_display(self, league=None):
         if self.final_rating is not None:

--- a/heltour/tournament/templates/tournament/availability.html
+++ b/heltour/tournament/templates/tournament/availability.html
@@ -45,13 +45,13 @@
                                 <tr>
                                     <td>Round {{ r.number }}</td>
                                     <td>{{ r.start_date|date_or_q:'%b %-d' }} - {{ r.end_date|date_or_q:'%b %-d' }}</td>
-                                    {% for p, is_av, is_fixed in av_list %}
+                                    {% for p, is_av, cannot_change in av_list %}
                                         <td>
                                             <input type="checkbox" name="av_r{{ r.number }}_{{ p.lichess_username }}"
                                                    data-toggle="toggle" data-on="Unavailable" data-off="Available"
                                                    data-onstyle="default" data-offstyle="success" data-size="small"
                                                    {% if not is_av %}checked{% endif %}
-                                                   {% if is_fixed %} disabled="true" {% endif %}
+                                                   {% if cannot_change %} disabled="true" {% endif %}
                                             />
                                         </td>
                                     {% endfor %}

--- a/heltour/tournament/templates/tournament/availability.html
+++ b/heltour/tournament/templates/tournament/availability.html
@@ -45,13 +45,13 @@
                                 <tr>
                                     <td>Round {{ r.number }}</td>
                                     <td>{{ r.start_date|date_or_q:'%b %-d' }} - {{ r.end_date|date_or_q:'%b %-d' }}</td>
-                                    {% for p, is_av, cannot_change in av_list %}
+                                    {% for p, is_av, is_immutable in av_list %}
                                         <td>
                                             <input type="checkbox" name="av_r{{ r.number }}_{{ p.lichess_username }}"
                                                    data-toggle="toggle" data-on="Unavailable" data-off="Available"
                                                    data-onstyle="default" data-offstyle="success" data-size="small"
                                                    {% if not is_av %}checked{% endif %}
-                                                   {% if cannot_change %} disabled="true" {% endif %}
+                                                   {% if is_immutable %} disabled="true" {% endif %}
                                             />
                                         </td>
                                     {% endfor %}

--- a/heltour/tournament/templates/tournament/availability.html
+++ b/heltour/tournament/templates/tournament/availability.html
@@ -45,13 +45,13 @@
                                 <tr>
                                     <td>Round {{ r.number }}</td>
                                     <td>{{ r.start_date|date_or_q:'%b %-d' }} - {{ r.end_date|date_or_q:'%b %-d' }}</td>
-                                    {% for p, is_av, is_red in av_list %}
+                                    {% for p, is_av, is_fixed in av_list %}
                                         <td>
                                             <input type="checkbox" name="av_r{{ r.number }}_{{ p.lichess_username }}"
                                                    data-toggle="toggle" data-on="Unavailable" data-off="Available"
                                                    data-onstyle="default" data-offstyle="success" data-size="small"
                                                    {% if not is_av %}checked{% endif %}
-                                                   {% if is_red %} disabled="true" {% endif %}
+                                                   {% if is_fixed %} disabled="true" {% endif %}
                                             />
                                         </td>
                                     {% endfor %}

--- a/heltour/tournament/views.py
+++ b/heltour/tournament/views.py
@@ -200,7 +200,7 @@ class HomeView(BaseView):
 
 class LeagueHomeView(LeagueView):
     def view(self):
-        if self.league.competitor_type == 'team':
+        if self.league.is_team_league():
             return self.team_view()
         else:
             return self.lone_view()
@@ -286,7 +286,7 @@ class LeagueHomeView(LeagueView):
 
 class SeasonLandingView(SeasonView):
     def view(self):
-        if self.league.competitor_type == 'team':
+        if self.league.is_team_league():
             return self.team_view()
         else:
             return self.lone_view()
@@ -437,7 +437,7 @@ class SeasonLandingView(SeasonView):
 
 class PairingsView(SeasonView):
     def view(self, round_number=None, team_number=None):
-        if self.league.competitor_type == 'team':
+        if self.league.is_team_league():
             return self.team_view(round_number, team_number)
         else:
             return self.lone_view(round_number, team_number)
@@ -649,7 +649,7 @@ class PairingsView(SeasonView):
 
 class ICalPairingsView(PairingsView, ICalMixin):
     def view(self, round_number=None, team_number=None):
-        if self.league.competitor_type == 'team':
+        if self.league.is_team_league():
             return self.team_view(round_number, team_number)
         else:
             return self.lone_view(round_number, team_number)
@@ -892,7 +892,7 @@ class RostersView(SeasonView):
 
 class StandingsView(SeasonView):
     def view(self, section=None):
-        if self.league.competitor_type == 'team':
+        if self.league.is_team_league():
             return self.team_view()
         else:
             return self.lone_view(section)
@@ -1036,7 +1036,7 @@ class WallchartView(SeasonView):
     def view(self):
         @cached_as(*common_lone_models)
         def _view(league_tag, season_tag, user_data):
-            if self.league.competitor_type == 'team':
+            if self.league.is_team_league():
                 raise Http404
             round_numbers = list(range(1, self.season.rounds + 1))
             player_scores = _lone_player_scores(self.season, sort_by_seed=True,
@@ -1061,7 +1061,7 @@ class WallchartView(SeasonView):
 
 class StatsView(SeasonView):
     def view(self):
-        if self.league.competitor_type == 'team':
+        if self.league.is_team_league():
             return self.team_view()
         else:
             return self.lone_view()
@@ -1205,7 +1205,7 @@ class StatsView(SeasonView):
 
 class BoardScoresView(SeasonView):
     def view(self, board_number):
-        if self.league.competitor_type == 'team':
+        if self.league.is_team_league():
             return self.team_view(board_number)
         else:
             raise Http404
@@ -1297,7 +1297,7 @@ class BoardScoresView(SeasonView):
 
 class LeagueDashboardView(LeagueView):
     def view(self):
-        if self.league.competitor_type == 'team':
+        if self.league.is_team_league():
             return self.team_view()
         else:
             return self.lone_view()
@@ -1491,7 +1491,7 @@ class PlayerProfileView(LeagueView):
         player = get_object_or_404(Player, lichess_username__iexact=username)
 
         def game_count(season):
-            if season.league.competitor_type == 'team':
+            if season.league.is_team_league():
                 season_pairings = TeamPlayerPairing.objects.filter(
                     team_pairing__round__season=season)
             else:
@@ -1500,7 +1500,7 @@ class PlayerProfileView(LeagueView):
                 black=player)).count()
 
         def team(season):
-            if season.league.competitor_type == 'team':
+            if season.league.is_team_league():
                 team_member = player.teammember_set.filter(team__season=season).first()
                 if team_member is not None:
                     return team_member.team
@@ -1526,7 +1526,7 @@ class PlayerProfileView(LeagueView):
             games = defaultdict(list)
             if season is None:
                 byes = {}
-            elif season.league.competitor_type == 'team':
+            elif season.league.is_team_league():
                 pairings = TeamPlayerPairing.objects.filter(
                     white=player) | TeamPlayerPairing.objects.filter(black=player)
                 for p in pairings.filter(team_pairing__round__season=season).order_by(
@@ -1601,7 +1601,7 @@ class PlayerProfileView(LeagueView):
                         continue
                     schedule.append((round_, pairing, None, None))
                 continue
-            if self.season.league.competitor_type == 'team':
+            if self.season.league.is_team_league():
                 assignment = AlternateAssignment.objects.filter(round=round_, player=player).first()
                 if assignment is not None and (
                     team_member is None or team_member.team != assignment.team):
@@ -1680,7 +1680,7 @@ class TeamProfileView(LeagueView):
 
         matches = []
         for round_ in self.season.round_set.filter(publish_pairings=True).order_by('number'):
-            if self.season.league.competitor_type == 'team':
+            if self.season.league.is_team_league():
                 pairing = team.pairings.filter(round=round_).first()
             if pairing is not None:
                 matches.append((round_, pairing))
@@ -1700,7 +1700,7 @@ class NominateView(SeasonView, LoginRequiredMixin):
         form = None
         player = self.player
 
-        if self.league.competitor_type == 'team':
+        if self.league.is_team_league():
             season_pairings = PlayerPairing.objects.filter(
                 teamplayerpairing__team_pairing__round__season=self.season).nocache()
         else:
@@ -1839,7 +1839,7 @@ class AvailabilityView(SeasonView, LoginRequiredMixin):
             season_player_set = SeasonPlayer.objects.filter(player__in=player_list, season=self.season).nocache()
             has_red_card_dict = {sp.player : sp.card_color == "red" for sp in season_player_set}
             
-            if self.league.competitor_type == 'team':
+            if self.league.is_team_league():
                 #games can only be scheduled for the current round
                 game_is_scheduled_dict = {(round_list[0], sp.player) : sp.has_scheduled_game_in_round(round_list[0]) for sp in season_player_set}
             else:


### PR DESCRIPTION
fixes #450 
if players already have a scheduled game for a round they cannot set
themselves unavailable anymore.
This only affects the team league directly, as in lonewolf and chess960
you cannot set yourself unavailable for an ongoing round anyway.