### PR TITLE
fixes #408 season player comments shown in edit rosters view

### DIFF
--- a/heltour/tournament/templates/tournament/admin/edit_rosters_player_info.html
+++ b/heltour/tournament/templates/tournament/admin/edit_rosters_player_info.html
@@ -55,6 +55,12 @@
             <td>{% render_comment_list for player %}</td>
         </tr>
     {% endif %}
+    {% get_comment_list for season_player as sp_comments %}
+    {% if sp_comments %}
+        <tr>
+            <td>{% render_comment_list for season_player %}</td>
+        </tr>
+    {% endif %}
     <tr>
         <td colspan="2"><input type="checkbox" class="captain-checkbox" id="captain"/><label
                 for="captain">Captain</label></div></td>


### PR DESCRIPTION
fixes #408 Season player comments are now shown in the player callout on the "edit rosters" view