### PR TITLE
withdrawal handling in team league

### DIFF
--- a/heltour/tournament/models.py
+++ b/heltour/tournament/models.py
@@ -1887,7 +1887,7 @@ class SeasonPlayer(_BaseModel):
             self.is_active = False
             self.save()
         self._set_unavailable_for_season(skip_current=True)
-        add_system_comment(self, 'player withdrawn for %s'%round)
+        add_system_comment(self, 'player withdrawn: %s'%round)
 
     @property
     def card_color(self):


### PR DESCRIPTION
fixes #465
when a player withdraws for team league they are
- set unavailable for future rounds
- if they are an alternate the SeasonPlayer is set inactive
- if teams have not been created yet the SeasonPlayer is set inactive
- A comment about the withdrawal is added to the SeasonPlayer
- sending message to captains channel is skipped. This is handled in issue 448