### PR TITLE
187 improve chesster notifications

### DIFF
--- a/heltour/tournament/automod.py
+++ b/heltour/tournament/automod.py
@@ -3,6 +3,7 @@ from heltour.tournament.models import *
 from django.db.models.signals import post_save
 from django.dispatch.dispatcher import receiver
 from heltour.tournament.tasks import pairings_published
+from textwrap import dedent
 import reversion
 import time
 
@@ -201,8 +202,8 @@ def claim_win_noshow_created(instance, **kwargs):
     if p.get_player_presence(instance.requester).online_for_game \
         and not p.get_player_presence(opponent).online_for_game \
         and timezone.now() > p.scheduled_time + timedelta(minutes=21):
-        instance.approve(response='You\'ve been given a win by forfeit. \
-        It is still possible to reschedule and play the game if you want to.')
+        instance.approve(
+            response='You\'ve been given a win by forfeit. It is still possible to reschedule and play the game if you want to.')
 
 
 @receiver(signals.mod_request_approved, sender=MOD_REQUEST_SENDER['claim_win_noshow'],

--- a/heltour/tournament/automod.py
+++ b/heltour/tournament/automod.py
@@ -55,7 +55,7 @@ def withdraw_created(instance, **kwargs):
         instance.reject(response='You can\'t withdraw from the season at this time.')
         return
 
-    instance.approve(response='You\'ve been withdrawn for round %d.' % instance.round.number)
+    instance.approve(response='You\'ve been withdrawn from the season. The withdrawal takes effect at the start of round %d.' % instance.round.number)
 
 
 @receiver(signals.mod_request_approved, sender=MOD_REQUEST_SENDER['withdraw'],
@@ -201,7 +201,8 @@ def claim_win_noshow_created(instance, **kwargs):
     if p.get_player_presence(instance.requester).online_for_game \
         and not p.get_player_presence(opponent).online_for_game \
         and timezone.now() > p.scheduled_time + timedelta(minutes=21):
-        instance.approve(response='You\'ve been given a win by forfeit.')
+        instance.approve(response='You\'ve been given a win by forfeit. \
+        It is still possible to reschedule and play the game if you want to.')
 
 
 @receiver(signals.mod_request_approved, sender=MOD_REQUEST_SENDER['claim_win_noshow'],

--- a/heltour/tournament/notify.py
+++ b/heltour/tournament/notify.py
@@ -832,6 +832,7 @@ def notify_noshow_claim(round_, player, punishment, allow_continue, **kwargs):
         continue_url = abs_url(reverse('by_league:by_season:modrequest',
                                        args=[league.tag, season.tag, 'request_continuation']))
         message += '\nOtherwise, if you want to continue playing next round, <%s|click here>.' % continue_url
+    message += '\nNote that you can reach out to your opponent and try to reschedule the game.'
     _message_user(league, _slack_user(player), message)
 
 


### PR DESCRIPTION
- fixes #187 mention that players are allowed to reschedule their game
after a no-show
- Specifies that a withdrawal is effective for the full season as the
previous reply has lead to confusion by some players.