### PR TITLE
fixes #449 improved accessibility of availability screen

### DIFF
--- a/heltour/tournament/templates/tournament/availability.html
+++ b/heltour/tournament/templates/tournament/availability.html
@@ -58,20 +58,18 @@
                                     <td>{{ r.start_date|date_or_q:'%b %-d' }} - {{ r.end_date|date_or_q:'%b %-d' }}</td>
                                     {% for p, is_av, is_immutable in av_list %}
                                         <td>
-                                            {% with id="{{ r.number }}_{{ p.lichess_username }}" %}
-                                                <input id="availability-checkbox-{{ id }}"
-                                                       type="checkbox" name="av_r{{ id }}"
-                                                       data-toggle="toggle" data-on="Unavailable" data-off="Available"
-                                                       data-onstyle="default" data-offstyle="success" data-size="small"
-                                                       onchange="availabilityChanged(this, document.getElementById('availability-checkbox-label-{{ r.number }}_{{ p.lichess_username }}'))"
-                                                       {% if not is_av %}checked{% endif %}
-                                                       {% if is_immutable %} disabled="true" {% endif %}
-                                                />
-                                                <label id="availability-checkbox-label-{{ r.number }}_{{ p.lichess_username }}" 
-                                                       for="availability-checkbox-{{ r.number }}_{{ p.lichess_username }}" 
-                                                       aria-label="Current setting: {% if is_av %} available {% else %} unavailable {% endif %}"
-                                                />
-                                            {% endwith %}
+                                            <input id="availability-checkbox-{{ r.number }}_{{ p.lichess_username }}"
+                                                   type="checkbox" name="av_r{{ r.number }}_{{ p.lichess_username }}"
+                                                   data-toggle="toggle" data-on="Unavailable" data-off="Available"
+                                                   data-onstyle="default" data-offstyle="success" data-size="small"
+                                                   onchange="availabilityChanged(this, document.getElementById('availability-checkbox-label-{{ r.number }}_{{ p.lichess_username }}'))"
+                                                   {% if not is_av %}checked{% endif %}
+                                                   {% if is_immutable %} disabled="true" {% endif %}
+                                            />
+                                            <label id="availability-checkbox-label-{{ r.number }}_{{ p.lichess_username }}" 
+                                                   for="availability-checkbox-{{ r.number }}_{{ p.lichess_username }}" 
+                                                   aria-label="Current setting: {% if is_av %} available {% else %} unavailable {% endif %}"
+                                            />
                                         </td>
                                     {% endfor %}
                                 </tr>

--- a/heltour/tournament/templates/tournament/availability.html
+++ b/heltour/tournament/templates/tournament/availability.html
@@ -13,6 +13,17 @@
 
 {% block content %}
     <script type="text/javascript" src="{% static 'lib/js/bootstrap-toggle.min.js' %}"></script>
+
+    <script>
+    function availabilityChanged(checkbox, label) {
+      if (checkbox.checked) {
+          label.setAttribute("aria-label","Current setting: unavailable - press save to submit");
+      } else {
+          label.setAttribute("aria-label", "Current setting: available - press save to submit");
+      }
+    }
+</script>
+
     <div class="row row-condensed-xs">
         <div class="col-md-12">
             <div class="well">
@@ -31,7 +42,7 @@
 
                     <form action="" method="post">
                         {% csrf_token %}
-                        <table class="table" id="table-availability">
+                        <table class="table" id="table-availability" summary="Availability settings per round">
                             <thead>
                             <tr>
                                 <th colspan="2">Availability</th>
@@ -47,11 +58,17 @@
                                     <td>{{ r.start_date|date_or_q:'%b %-d' }} - {{ r.end_date|date_or_q:'%b %-d' }}</td>
                                     {% for p, is_av, is_immutable in av_list %}
                                         <td>
-                                            <input type="checkbox" name="av_r{{ r.number }}_{{ p.lichess_username }}"
+                                            <input id="availability-checkbox-{{ r.number }}_{{ p.lichess_username }}"
+                                                   type="checkbox" name="av_r{{ r.number }}_{{ p.lichess_username }}"
                                                    data-toggle="toggle" data-on="Unavailable" data-off="Available"
                                                    data-onstyle="default" data-offstyle="success" data-size="small"
+                                                   onchange="availabilityChanged(this, document.getElementById('availability-checkbox-label-{{ r.number }}_{{ p.lichess_username }}'))"
                                                    {% if not is_av %}checked{% endif %}
                                                    {% if is_immutable %} disabled="true" {% endif %}
+                                            />
+                                            <label id="availability-checkbox-label-{{ r.number }}_{{ p.lichess_username }}" 
+                                                   for="availability-checkbox-{{ r.number }}_{{ p.lichess_username }}" 
+                                                   aria-label="Current setting: {% if is_av %} available {% else %} unavailable {% endif %}"
                                             />
                                         </td>
                                     {% endfor %}
@@ -65,4 +82,5 @@
             </div>
         </div>
     </div>
+
 {% endblock %}

--- a/heltour/tournament/templates/tournament/availability.html
+++ b/heltour/tournament/templates/tournament/availability.html
@@ -22,7 +22,7 @@
           label.setAttribute("aria-label", "Current setting: available - press save to submit");
       }
     }
-</script>
+    </script>
 
     <div class="row row-condensed-xs">
         <div class="col-md-12">
@@ -58,18 +58,20 @@
                                     <td>{{ r.start_date|date_or_q:'%b %-d' }} - {{ r.end_date|date_or_q:'%b %-d' }}</td>
                                     {% for p, is_av, is_immutable in av_list %}
                                         <td>
-                                            <input id="availability-checkbox-{{ r.number }}_{{ p.lichess_username }}"
-                                                   type="checkbox" name="av_r{{ r.number }}_{{ p.lichess_username }}"
-                                                   data-toggle="toggle" data-on="Unavailable" data-off="Available"
-                                                   data-onstyle="default" data-offstyle="success" data-size="small"
-                                                   onchange="availabilityChanged(this, document.getElementById('availability-checkbox-label-{{ r.number }}_{{ p.lichess_username }}'))"
-                                                   {% if not is_av %}checked{% endif %}
-                                                   {% if is_immutable %} disabled="true" {% endif %}
-                                            />
-                                            <label id="availability-checkbox-label-{{ r.number }}_{{ p.lichess_username }}" 
-                                                   for="availability-checkbox-{{ r.number }}_{{ p.lichess_username }}" 
-                                                   aria-label="Current setting: {% if is_av %} available {% else %} unavailable {% endif %}"
-                                            />
+                                            {% with id="{{ r.number }}_{{ p.lichess_username }}" %}
+                                                <input id="availability-checkbox-{{ id }}"
+                                                       type="checkbox" name="av_r{{ id }}"
+                                                       data-toggle="toggle" data-on="Unavailable" data-off="Available"
+                                                       data-onstyle="default" data-offstyle="success" data-size="small"
+                                                       onchange="availabilityChanged(this, document.getElementById('availability-checkbox-label-{{ r.number }}_{{ p.lichess_username }}'))"
+                                                       {% if not is_av %}checked{% endif %}
+                                                       {% if is_immutable %} disabled="true" {% endif %}
+                                                />
+                                                <label id="availability-checkbox-label-{{ r.number }}_{{ p.lichess_username }}" 
+                                                       for="availability-checkbox-{{ r.number }}_{{ p.lichess_username }}" 
+                                                       aria-label="Current setting: {% if is_av %} available {% else %} unavailable {% endif %}"
+                                                />
+                                            {% endwith %}
                                         </td>
                                     {% endfor %}
                                 </tr>


### PR DESCRIPTION
fixes #449 by adding an aria-label that is linked to the current setting of the availability toggles to present hints to blind users. Not a great solution imo but short term the best I can provide. Long term solution might be to replace the bootstrap toggles altogether or to improve the implementation of these hints.