### PR TITLE
allow provisional players for team

### DIFF
--- a/heltour/tournament/teamgen.py
+++ b/heltour/tournament/teamgen.py
@@ -147,7 +147,7 @@ def flatten(lst):
 def make_league(playerdata, boards, balance):
     players = []
     for player in playerdata:
-        if player['has_20_games'] and player['in_slack']:
+        if player['in_slack']:
             players.append(Player.player_from_json(player))
         else:
             pass


### PR DESCRIPTION
fixes #473. i have confirmed that this works as the team mods want in a small test season.
i have also decided to leave provisional players in red_players, that way it is still possible to check for registrations that were accepted by mistake.