### PR TITLE
validate pending registrations daily

### DIFF
--- a/heltour/settings_default.py
+++ b/heltour/settings_default.py
@@ -216,6 +216,11 @@ CELERYBEAT_SCHEDULE = {
         'schedule': timedelta(minutes=1),
         'args': ()
     },
+    'validate_pending_registrations': {
+        'task': 'heltour.tournament.tasks.validate_pending_registrations',
+        'schedule': timedelta(days=1),
+        'args': ()
+    },
     'celery_is_up': {
         'task': 'heltour.tournament.tasks.celery_is_up',
         'schedule': timedelta(minutes=5),


### PR DESCRIPTION
once a day, validate pending registrations. this closes #200, in a manner of speaking. instead of updating the rating and only then triggering validation on players with established rating, it simply triggers validation of all pending registrations. i am not certain how big the difference is, since as far as i can tell, a validation will force an update of the rating anyway.

running this every second day would be perfectly ok as well.