### PR TITLE
more filters when requesting game metas

### DIFF
--- a/heltour/tournament/lichessapi.py
+++ b/heltour/tournament/lichessapi.py
@@ -111,9 +111,9 @@ def get_game_meta(gameid, priority=0, max_retries=5, timeout=1800):
     return json.loads(result)
 
 
-def get_latest_game_metas(*, lichess_username, since, number, opponent, priority=0, max_retries=5, timeout=1800):
-    url = f'{settings.API_WORKER_HOST}/lichessapi/api/games/user/{lichess_username}?since={since}&max={number}\
-            &vs={opponent}&ongoing=true&priority={priority}&max_retries={max_retries}&format=application/x-ndjson'
+def get_latest_game_metas(*, lichess_username, since, number, opponent, variant, priority=0, max_retries=5, timeout=1800):
+    url = (f'{settings.API_WORKER_HOST}/lichessapi/api/games/user/{lichess_username}?since={since}&max={number}'
+           f'&vs={opponent}&perfType="{variant}"&ongoing=true&priority={priority}&max_retries={max_retries}&format=application/x-ndjson')
     result = _apicall_with_error_parsing(url, timeout)
     return [json.loads(g) for g in result.split('\n') if g.strip()]
 

--- a/heltour/tournament/lichessapi.py
+++ b/heltour/tournament/lichessapi.py
@@ -111,9 +111,9 @@ def get_game_meta(gameid, priority=0, max_retries=5, timeout=1800):
     return json.loads(result)
 
 
-def get_latest_game_metas(lichess_username, number, priority=0, max_retries=5, timeout=1800):
-    url = '%s/lichessapi/api/games/user/%s?max=%s&ongoing=true&priority=%s&max_retries=%s&format=application/x-ndjson' % (
-        settings.API_WORKER_HOST, lichess_username, number, priority, max_retries)
+def get_latest_game_metas(lichess_username, since, number, opponent, priority=0, max_retries=5, timeout=1800):
+    url = '%s/lichessapi/api/games/user/%s?since=%s&max=%s&vs=%s&ongoing=true&priority=%s&max_retries=%s&format=application/x-ndjson' % (
+        settings.API_WORKER_HOST, lichess_username, since, number, opponent, priority, max_retries)
     result = _apicall_with_error_parsing(url, timeout)
     return [json.loads(g) for g in result.split('\n') if g.strip()]
 

--- a/heltour/tournament/lichessapi.py
+++ b/heltour/tournament/lichessapi.py
@@ -111,9 +111,9 @@ def get_game_meta(gameid, priority=0, max_retries=5, timeout=1800):
     return json.loads(result)
 
 
-def get_latest_game_metas(lichess_username, since, number, opponent, priority=0, max_retries=5, timeout=1800):
-    url = '%s/lichessapi/api/games/user/%s?since=%s&max=%s&vs=%s&ongoing=true&priority=%s&max_retries=%s&format=application/x-ndjson' % (
-        settings.API_WORKER_HOST, lichess_username, since, number, opponent, priority, max_retries)
+def get_latest_game_metas(*, lichess_username, since, number, opponent, priority=0, max_retries=5, timeout=1800):
+    url = f'{settings.API_WORKER_HOST}/lichessapi/api/games/user/{lichess_username}?since={since}&max={number}\
+            &vs={opponent}&ongoing=true&priority={priority}&max_retries={max_retries}&format=application/x-ndjson'
     result = _apicall_with_error_parsing(url, timeout)
     return [json.loads(g) for g in result.split('\n') if g.strip()]
 

--- a/heltour/tournament/tasks.py
+++ b/heltour/tournament/tasks.py
@@ -235,9 +235,10 @@ def update_tv_state():
         try:
             league = game.get_round().season.league
             roundstart = round(game.get_round().start_date.timestamp()*1000) # round start in miliseconds
-            for meta in lichessapi.get_latest_game_metas(lichess_username=game.white.lichess_username, since=roundstart,
-                                       number=5, opponent=game.black.lichess_username, priority=1,
-                                       timeout=300):
+            for meta in lichessapi.get_latest_game_metas(lichess_username=game.white.lichess_username,
+                                                         variant=league.rating_type, since=roundstart,
+                                                         number=5, opponent=game.black.lichess_username, priority=1,
+                                                         timeout=300):
                 try:
                     if meta['players']['white']['user'][
                         'id'].lower() == game.white.lichess_username.lower() and \
@@ -245,6 +246,7 @@ def update_tv_state():
                             'id'].lower() == game.black.lichess_username.lower() and \
                         meta['clock']['initial'] == league.time_control_initial() and \
                         meta['clock']['increment'] == league.time_control_increment() and \
+                        meta['perf'] == league.rating_type and \
                         meta['rated'] == True:
                         game.game_link = get_gamelink_from_gameid(meta['id'])
                         game.save()

--- a/heltour/tournament/tasks.py
+++ b/heltour/tournament/tasks.py
@@ -234,8 +234,10 @@ def update_tv_state():
     for game in games_starting:
         try:
             league = game.get_round().season.league
-            for meta in lichessapi.get_latest_game_metas(game.white.lichess_username, 5, priority=1,
-                                                         timeout=300):
+            roundstart = (game.get_round().start_date - datetime(1970, 0, 1)).total_seconds()*1000 # round start in miliseconds
+            for meta in lichessapi.get_latest_game_metas(game.white.lichess_username, since=roundstart,
+                                       number=5, opponent=game.black.lichess_username, priority=1,
+                                       timeout=300):
                 try:
                     if meta['players']['white']['user'][
                         'id'].lower() == game.white.lichess_username.lower() and \

--- a/heltour/tournament/tasks.py
+++ b/heltour/tournament/tasks.py
@@ -234,7 +234,7 @@ def update_tv_state():
     for game in games_starting:
         try:
             league = game.get_round().season.league
-            roundstart = (game.get_round().start_date - datetime(1970, 0, 1)).total_seconds()*1000 # round start in miliseconds
+            roundstart = round(game.get_round().start_date.timestamp()*1000) # round start in miliseconds
             for meta in lichessapi.get_latest_game_metas(game.white.lichess_username, since=roundstart,
                                        number=5, opponent=game.black.lichess_username, priority=1,
                                        timeout=300):

--- a/heltour/tournament/tasks.py
+++ b/heltour/tournament/tasks.py
@@ -235,7 +235,7 @@ def update_tv_state():
         try:
             league = game.get_round().season.league
             roundstart = round(game.get_round().start_date.timestamp()*1000) # round start in miliseconds
-            for meta in lichessapi.get_latest_game_metas(game.white.lichess_username, since=roundstart,
+            for meta in lichessapi.get_latest_game_metas(lichess_username=game.white.lichess_username, since=roundstart,
                                        number=5, opponent=game.black.lichess_username, priority=1,
                                        timeout=300):
                 try:


### PR DESCRIPTION
closes #498. hopefully.

for games that are supposed to start soon, we requested the last games of the white player from lichess. we now filter these to only request games since the round started + only against the black player.

while i am still not certain how the bug above worked exactly, i assume that this should fix it. otherwise, i am out of ideas.

edit: rebased on #527

more edits: i believe this closes #255 as well.

edit to the edits: closes #202 too.