### PR TITLE
only change registration status to pending when some specific fields are edited

### DIFF
--- a/heltour/tournament/forms.py
+++ b/heltour/tournament/forms.py
@@ -203,7 +203,8 @@ class RegistrationForm(forms.ModelForm):
         registration = super(RegistrationForm, self).save(commit=False, *args, **kwargs)
         registration.season = self.season
         registration.lichess_username = str(self.username)
-        registration.status = 'pending'
+        if any(x in self.changed_data for x in ['alternate_preference', 'section_preference', 'weeks_unavailable']):
+            registration.status = 'pending'
         if commit:
             registration.save()
         registration.player().agreed_to_tos()

--- a/heltour/tournament/models.py
+++ b/heltour/tournament/models.py
@@ -742,9 +742,6 @@ ACCOUNT_STATUS_OPTIONS = (
 
 # -------------------------------------------------------------------------------
 class Player(_BaseModel):
-    # TODO: we should find out the real restrictions on a lichess username and
-    #       duplicate them here.
-    # Note: a case-insensitive unique index for lichess_username is added via migration to the DB
     lichess_username = models.CharField(max_length=255, validators=[username_validator])
     rating = models.PositiveIntegerField(blank=True, null=True)
     games_played = models.PositiveIntegerField(blank=True, null=True)
@@ -2496,7 +2493,6 @@ LEAGUE_CHANNEL_TYPES = (
 
 # -------------------------------------------------------------------------------
 class LeagueChannel(_BaseModel):
-    # TODO: Rename to LeagueChannel
     league = models.ForeignKey(League, on_delete=models.CASCADE)
     type = models.CharField(max_length=255, choices=LEAGUE_CHANNEL_TYPES)
     slack_channel = models.CharField(max_length=255)


### PR DESCRIPTION
only change registration status to pending when some specific fields are changed, that require mod review.

closes #554. as opposed to 554, we do not change status to pending when agreed_to_rules
or agreed_to_tos are changed, because, and this is true, they cannot be changed anyway.