### PR TITLE
fix: Always reset the db on start.

### DIFF
--- a/sysadmin/run-heltour-live-celery.sh
+++ b/sysadmin/run-heltour-live-celery.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 export HELTOUR_ENV=LIVE
 cd /home/lichess4545/web/www.lichess4545.com/
+rm -f ./celerybeat-schedule.db
+rm -f ./celerybeat-schedule.dat
+rm -f ./celerybeat-schedule.dir
 /home/lichess4545/web/www.lichess4545.com/env/bin/celery -A heltour worker -B -c 4 --loglevel=INFO -Ofair


### PR DESCRIPTION
We only use it for transient timer based cron-like jobs, and these will always be properly generated when an empty database is here, and when we last ran them is irrelevant.