### PR TITLE
fix debug-toolbar on vagrant

### DIFF
--- a/heltour/local/vagrant4545.py
+++ b/heltour/local/vagrant4545.py
@@ -2,7 +2,7 @@ DEBUG = True
 GOOGLE_SERVICE_ACCOUNT_KEYFILE_PATH = '/home/vagrant/heltour/gspread.conf'
 SLACK_API_TOKEN_FILE_PATH = '/home/vagrant/heltour/slack-token.conf'
 
-INTERNAL_IPS = ['127.0.0.1']
+INTERNAL_IPS = ['127.0.0.1', '10.0.2.2']
 JAVAFO_COMMAND = 'java -jar /home/vagrant/heltour/javafo.jar'
 STATIC_ROOT = '/home/vagrant/heltour/static'
 


### PR DESCRIPTION
vagrant uses 10.0.2.2 as the ip for the host system on the private network, so when accessing heltour on the guest from a browser on the host, this ip needs to be considered internal