### PR TITLE
fixes #407 by moving channel creation to the slack conversations API

### DIFF
--- a/heltour/settings.py
+++ b/heltour/settings.py
@@ -55,6 +55,8 @@ if os.path.exists(config_path):
                                                         GOOGLE_SERVICE_ACCOUNT_KEYFILE_PATH)
     SLACK_API_TOKEN_FILE_PATH = overrides.get('SLACK_API_TOKEN_FILE_PATH',
                                               SLACK_API_TOKEN_FILE_PATH)
+    SLACK_CHANNEL_BUILDER_TOKEN_FILE_PATH = overrides.get('SLACK_CHANNEL_BUILDER_TOKEN_FILE_PATH',
+                                              SLACK_CHANNEL_BUILDER_TOKEN_FILE_PATH)
     SLACK_WEBHOOK_FILE_PATH = overrides.get('SLACK_WEBHOOK_FILE_PATH', SLACK_WEBHOOK_FILE_PATH)
     LICHESS_API_TOKEN_FILE_PATH = overrides.get('LICHESS_API_TOKEN_FILE_PATH', LICHESS_API_TOKEN_FILE_PATH)
     FCM_API_KEY_FILE_PATH = overrides.get('FCM_API_KEY_FILE_PATH', FCM_API_KEY_FILE_PATH)

--- a/heltour/settings_default.py
+++ b/heltour/settings_default.py
@@ -314,6 +314,7 @@ TEAMGEN_PROCESSES_NUMBER = 8
 
 GOOGLE_SERVICE_ACCOUNT_KEYFILE_PATH = '/home/lichess4545/etc/heltour/gspread.conf'
 SLACK_API_TOKEN_FILE_PATH = '/home/lichess4545/etc/heltour/slack-token.conf'
+SLACK_CHANNEL_BUILDER_TOKEN_FILE_PATH = '/home/lichess4545/etc/heltour/slack-channel-builder-token.conf'
 SLACK_WEBHOOK_FILE_PATH = '/home/lichess4545/etc/heltour/slack-webhook.conf'
 LICHESS_API_TOKEN_FILE_PATH = '/home/lichess4545/etc/heltour/lichess-api-token.conf'
 JAVAFO_COMMAND = 'java -jar /home/lichess4545/etc/heltour/javafo.jar'

--- a/heltour/tournament/tasks.py
+++ b/heltour/tournament/tasks.py
@@ -614,13 +614,11 @@ def create_team_channel(team_ids):
             logger.error('Could not create slack team, name taken: %s' % channel_name)
             continue
         channel_ref = '#%s' % group.name
-        for user_id in user_ids:
-            if user_id:
-                try:
-                    slackapi.invite_to_group(group.id, user_id)
-                except slackapi.SlackError:
-                    logger.exception('Could not invite %s to slack' % user_id)
-                time.sleep(1)
+        try:
+            slackapi.invite_to_group(group.id, user_ids)
+        except slackapi.SlackError:
+            logger.exception('Could not invite %s to channel' % ",".join(user_ids))
+            time.sleep(1)
         slackapi.invite_to_group(group.id, settings.CHESSTER_USER_ID)
         time.sleep(1)
         with reversion.create_revision():


### PR DESCRIPTION
Needs a bot with groups:write scope
On the production server the OAuth token of that bot needs to go into a file '/home/lichess4545/etc/heltour/slack-channel-builder-token.conf'