### PR TITLE
delete links of aborted games

### DIFF
--- a/heltour/tournament/models.py
+++ b/heltour/tournament/models.py
@@ -1682,7 +1682,6 @@ class PlayerPairing(_BaseModel):
                 old_black_setting.save()
             self.update_available_upon_schedule(self.white_id)
             self.update_available_upon_schedule(self.black_id)
-    
 
     def delete(self, *args, **kwargs):
         team_pairing = None


### PR DESCRIPTION
checks whether games are aborted, and either does not add the game link in the first place, or removes it if it was already added.

closes #296.

this is the rebased version of #545, which can be closed too.