### PR TITLE
fix prototype-polluting function on chessground

### DIFF
--- a/heltour/tournament/static/lib/js/chessground.js
+++ b/heltour/tournament/static/lib/js/chessground.js
@@ -112,6 +112,11 @@ module.exports.drag = require('./drag');
 
 		for (var key in extend) {
 
+			// Skip dangerous properties to prevent prototype pollution
+			if (key === '__proto__' || key === 'constructor') {
+				continue;
+			}
+
 			if (typeOf(base[key]) === 'object' && typeOf(extend[key]) === 'object') {
 
 				base[key] = merge_recursive(base[key], extend[key]);


### PR DESCRIPTION
https://github.com/Lichess4545/heltour/blob/0e7b9c773a38d2961eadfe1d0434d484c9d14c3e/heltour/tournament/static/lib/js/chessground.js#L121-L121

fix the issue need to prevent prototype pollution by blocking the assignment of dangerous properties like `__proto__` and `constructor`. This can be achieved by adding a check inside the `for` loop in the `merge_recursive` function to skip these property names. This approach ensures that the function remains safe while preserving its existing functionality.

The changes will be made in the `merge_recursive` function, specifically in the loop where properties are copied from `extend` to `base`.

Most JavaScript objects inherit the properties of the built-in `Object.prototype` object. Prototype pollution is a type of vulnerability in which an attacker is able to modify `Object.prototype`. Since most objects inherit from the compromised `Object.prototype`, the attacker can use this to tamper with the application logic, and often escalate to remote code execution or cross-site scripting. One way to cause prototype pollution is through use of an unsafe merge or extend function to recursively copy properties from one object to another, or through the use of a deep assignment function to assign to an unverified chain of property names. Such a function has the potential to modify any object reachable from the destination object, and the built-in `Object.prototype` is usually reachable through the special properties `__proto__` and `constructor.prototype`.


## POC
This function recursively copies properties from `src` to `dst`:
```js
function merge(dst, src) {
    for (let key in src) {
        if (!src.hasOwnProperty(key)) continue;
        if (isObject(dst[key])) {
            merge(dst[key], src[key]);
        } else {
            dst[key] = src[key];
        }
    }
}
```
However, if `src` is the object `{"__proto__": {"isAdmin": true}}`, it will inject the property `isAdmin: true` in `Object.prototype`.
```js
function merge(dst, src) {
    for (let key in src) {
        if (!src.hasOwnProperty(key)) continue;
        if (dst.hasOwnProperty(key) && isObject(dst[key])) {
            merge(dst[key], src[key]);
        } else {
            dst[key] = src[key];
        }
    }
}
```
Alternatively, block the `__proto__` and `constructor` properties:
```js
function merge(dst, src) {
    for (let key in src) {
        if (!src.hasOwnProperty(key)) continue;
        if (key === "__proto__" || key === "constructor") continue;
        if (isObject(dst[key])) {
            merge(dst[key], src[key]);
        } else {
            dst[key] = src[key];
        }
    }
}
```
## References
[lodash](https://hackerone.com/reports/380873), [jQuery](https://hackerone.com/reports/454365), [extend](https://hackerone.com/reports/381185), [just-extend](https://hackerone.com/reports/430291), [merge.recursive](https://hackerone.com/reports/381194)
[CWE-78](https://cwe.mitre.org/data/definitions/78.html)
[CWE-79](https://cwe.mitre.org/data/definitions/79.html)
[CWE-94](https://cwe.mitre.org/data/definitions/94.html)
[CWE-400](https://cwe.mitre.org/data/definitions/400.html)
[CWE-471](https://cwe.mitre.org/data/definitions/471.html)
[CWE-915](https://cwe.mitre.org/data/definitions/915.html)