### PR TITLE
fix server error for calculating ljp when approving players without rating

### DIFF
--- a/heltour/tournament/models.py
+++ b/heltour/tournament/models.py
@@ -845,7 +845,7 @@ class Player(_BaseModel):
                 # self.profile is only None if the player profile has never been downloaded
                 # from lichess or the account had already been closed at that first download.
                 return 0
-            return self.profile.get('perfs', {}).get(league.rating_type, {}).get('rating')
+            return self.profile.get('perfs', {}).get(league.rating_type, {}).get('rating') or 0
         return self.rating
 
     def games_played_for(self, league):

--- a/heltour/tournament/models.py
+++ b/heltour/tournament/models.py
@@ -845,7 +845,7 @@ class Player(_BaseModel):
                 # self.profile is only None if the player profile has never been downloaded
                 # from lichess or the account had already been closed at that first download.
                 return 0
-            return self.profile.get('perfs', {}).get(league.rating_type, {}).get('rating') or 0
+            return self.profile.get('perfs', {}).get(league.rating_type, {}).get('rating', 0)
         return self.rating
 
     def games_played_for(self, league):

--- a/heltour/tournament/tests/test_models.py
+++ b/heltour/tournament/tests/test_models.py
@@ -428,7 +428,8 @@ class AlternateTestCase(TestCase):
 
         set_rating(player, None)
         alt.update_board_number()
-        self.assertEqual(2, alt.board_number)
+        # players with rating set to None return a rating of zero now, so lowest alt board
+        self.assertEqual(3, alt.board_number)
 
         set_rating(player, 2100)
         alt.update_board_number()

--- a/heltour/tournament/tests/test_workflows.py
+++ b/heltour/tournament/tests/test_workflows.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from django.test import TestCase
 from heltour.tournament.models import Player
@@ -9,17 +8,9 @@ from heltour.tournament.tests.testutils import createCommonLeagueData, create_re
 class TestLJPCase(TestCase):
     def setUp(self):
         createCommonLeagueData(round_count=7)
-        players = Player.objects.all()
-        rating = 1000
-        for player in players:
-            set_rating(player, rating)
-            rating += 100
-        set_rating(players[0], None)
 
-    def test_ljp(self, *args):
-        new_player = Player.objects.create(lichess_username="newplayer")
-        new_player.profile = json.loads('{"perfs": {"bullet": {"games": 50, "rating": 1650, "rd": 45, "prog": 10}}}')
-        new_player.save()
+    def test_ljp_none_rating(self, *args):
+        new_player = Player.objects.create(lichess_username="newplayer", profile={"perfs": {"bullet": {"games": 50, "rating": 1650, "rd": 45, "prog": 10}}})
         season = get_season("lone")
         logging.disable(logging.CRITICAL)
         reg = create_reg(season, "newplayer")

--- a/heltour/tournament/tests/test_workflows.py
+++ b/heltour/tournament/tests/test_workflows.py
@@ -1,0 +1,30 @@
+import json
+import logging
+from django.test import TestCase
+from heltour.tournament.models import Player
+from heltour.tournament.workflows import ApproveRegistrationWorkflow
+from heltour.tournament.tests.testutils import createCommonLeagueData, create_reg, get_season, set_rating
+
+
+class TestLJPCase(TestCase):
+    def setUp(self):
+        createCommonLeagueData(round_count=7)
+        players = Player.objects.all()
+        rating = 1000
+        for player in players:
+            set_rating(player, rating)
+            rating += 100
+        set_rating(players[0], None)
+
+    def test_ljp(self, *args):
+        new_player = Player.objects.create(lichess_username="newplayer")
+        new_player.profile = json.loads('{"perfs": {"bullet": {"games": 50, "rating": 1650, "rd": 45, "prog": 10}}}')
+        new_player.save()
+        season = get_season("lone")
+        logging.disable(logging.CRITICAL)
+        reg = create_reg(season, "newplayer")
+        logging.disable(logging.NOTSET)
+        arw = ApproveRegistrationWorkflow(reg, 4)
+        self.assertEqual(arw.default_byes, 2)
+        self.assertEqual(arw.active_round_count, 3)
+        self.assertEqual(arw.default_ljp, 0)

--- a/heltour/tournament/tests/testutils.py
+++ b/heltour/tournament/tests/testutils.py
@@ -52,9 +52,8 @@ def get_round(league_type, round_number):
     return Round.objects.get(season=get_season(league_type), number=round_number)
 
 
-def createCommonLeagueData():
+def createCommonLeagueData(round_count=3):
     team_count = 4
-    round_count = 3
     board_count = 2
 
     league = League.objects.create(name='Team League', tag=league_tag('team'),


### PR DESCRIPTION
* make `player.rating_for(league)` return 0 instead of none if the player has never played any games in that rating category.
* add a test for that situation, which fails before this pr
* add a round_count parameter for `createCommonLeagueData` since creating a failing test (easily) requires more rounds than the hardcoded 3.
* fix another test, since this change makes `player.rating_for(league)` return 0 even when the rating was set to None manually.

these changes will hopefully only be relevant for leagues that would approve players who have never played any games, which is currently the chess960 league only.

closes #636.