### PR TITLE
temporarily disable link for contacting players on slack

### DIFF
--- a/heltour/tournament/templates/tournament/player_profile.html
+++ b/heltour/tournament/templates/tournament/player_profile.html
@@ -42,11 +42,13 @@
                     <h3>Contact</h3>
                 </div>
                 <div class="well-body">
+{% comment %} feature temporarily disabled because of slack leaking usernames which cannot be changed on an unpaid instance
                     {% if player.slack_user_id %}
                         <div>
                           <a href="https://slack.com/app_redirect?team={{ slack_id }}&channel={{ player.slack_user_id }}">Message {{ player.lichess_username }}
                                 on Slack</a></div>
                     {% endif %}
+{% endcomment %}              
                     <div>
                         <a href="https://lichess.org/inbox/new?user={{ player.lichess_username }}">Message {{ player.lichess_username }}
                             on Lichess</a></div>


### PR DESCRIPTION
disable feature that leaks usernames, hopefully temporarily.