### PR TITLE
fix some problems appearing with the shortened registration

### DIFF
--- a/heltour/tournament/notify.py
+++ b/heltour/tournament/notify.py
@@ -77,7 +77,7 @@ def registration_saved(instance, created, **kwargs):
         instance.season.pk))
     pending_count = instance.season.registration_set.filter(status='pending',
                                                             season=instance.season).count()
-    message = f'@{instance.lichess_username} (instance.rating) has <{reg_url}|registered> for {league.name}. <{list_url}|{pending_count} pending>'
+    message = f'@{instance.lichess_username} ({instance.rating}) has <{reg_url}|registered> for {league.name}. <{list_url}|{pending_count} pending>'
 
     pre_season = instance.season.start_date and timezone.now() < instance.season.start_date
     setting = league.get_leaguesetting()

--- a/heltour/tournament/tasks.py
+++ b/heltour/tournament/tasks.py
@@ -568,8 +568,6 @@ def validate_registration(reg_id):
         reg.has_played_20_games = not player.provisional_for(reg.season.league)
         if player.account_status != 'normal':
             fail_reason = f'The lichess user "{reg.lichess_username}" has the "{player.account_status}" mark.'
-        if reg.already_in_slack_group and not player.slack_user_id:
-            regquery.update(already_in_slack_group = False)
     except lichessapi.ApiWorkerError:
         fail_reason = f'The lichess user "{reg.lichess_username}" could not be found.'
     except lichessapi.ApiClientError:

--- a/heltour/tournament/tasks.py
+++ b/heltour/tournament/tasks.py
@@ -568,10 +568,10 @@ def validate_registration(reg_id):
         reg.has_played_20_games = not player.provisional_for(reg.season.league)
         if player.account_status != 'normal':
             fail_reason = f'The lichess user "{reg.lichess_username}" has the "{player.account_status}" mark.'
-    except lichessapi.ApiWorkerError:
-        fail_reason = f'The lichess user "{reg.lichess_username}" could not be found.'
     except lichessapi.ApiClientError:
         fail_reason = f'Client error retrieving user "{reg.lichess_username}" from lichess.'
+    except lichessapi.ApiWorkerError:
+        fail_reason = f'The lichess user "{reg.lichess_username}" could not be found.'
 
     if not reg.has_played_20_games:
         warnings.append('Has a provisional rating.')

--- a/heltour/tournament/tests/test_login.py
+++ b/heltour/tournament/tests/test_login.py
@@ -1,12 +1,11 @@
 import datetime
-import logging
 import responses
 from django.test import TestCase
 from django.urls import reverse
 from unittest.mock import patch
 from heltour.tournament import oauth
 from heltour.tournament.models import LoginToken, Player, User
-from heltour.tournament.tests.testutils import createCommonLeagueData, get_league, league_tag, league_url, season_url
+from heltour.tournament.tests.testutils import createCommonLeagueData, get_league, league_tag, league_url, season_url, Shush
 import re
 
 
@@ -157,13 +156,10 @@ class LoginBadTestCase(TestCase):
 
     def test_bad_response(self, *args):
         # failed logins write to the log, disable logging temporarily for nicer test output
-        logging.disable(logging.CRITICAL)
-        try:
+        with Shush():
             response = self.client.get(reverse('lichess_auth'), {'code': 'abc'}, follow=True)
             self.assertTemplateUsed(response, 'tournament/login_failed.html')
             response = self.client.get(reverse('lichess_auth'), {'state': 'abc'}, follow=True)
             self.assertTemplateUsed(response, 'tournament/login_failed.html')
             response = self.client.get(reverse('lichess_auth'), {'code': 'abc', 'state': 'abc'}, follow=True)
-        finally:
-            logging.disable(logging.NOTSET)
         self.assertTemplateUsed(response, 'tournament/login_failed.html')

--- a/heltour/tournament/tests/test_models.py
+++ b/heltour/tournament/tests/test_models.py
@@ -1,4 +1,3 @@
-import logging
 from django.test import TestCase, SimpleTestCase
 from django.utils import timezone
 from datetime import datetime, timedelta
@@ -9,7 +8,7 @@ from heltour.tournament.models import (add_system_comment, Alternate,
         ScheduledNotification, Season, SeasonPlayer, Team, TeamPairing,
         TeamPlayerPairing, TeamScore)
 from heltour.tournament.tests.testutils import (createCommonLeagueData,
-        create_reg, get_league, get_season, set_rating)
+        create_reg, get_league, get_season, set_rating, Shush)
 
 
 class HelpersTestCase(SimpleTestCase):
@@ -476,11 +475,11 @@ class RegistrationTestCase(TestCase):
 
     def test_registration_previous(self):
         season = get_season('team')
-        reg = create_reg(season, 'testuser')
+        reg = create_reg(season, 'Player1')
 
         self.assertEqual([], list(reg.previous_registrations()))
 
-        reg2 = create_reg(season, 'testuser')
+        reg2 = create_reg(season, 'Player1')
         self.assertEqual([], list(reg.previous_registrations()))
         self.assertEqual([reg], list(reg2.previous_registrations()))
 
@@ -549,12 +548,8 @@ class AlternateTestCase(TestCase):
 
         time1 = timezone.now()
         # creating a reg writes to the log, disable that temporarily for nicer test output
-        logging.disable(logging.CRITICAL)
-        try:
-            sp.registration = create_reg(sp.season, 'testuser')
-            sp.save()
-        finally:
-            logging.disable(logging.NOTSET)
+        with Shush():
+            sp.registration = create_reg(sp.season, 'Player1')
         time2 = timezone.now()
 
         self.assertTrue(time1 <= alt.priority_date() <= time2)

--- a/heltour/tournament/tests/test_tasks.py
+++ b/heltour/tournament/tests/test_tasks.py
@@ -147,25 +147,25 @@ class TestValidateRegistration(TestCase):
         s = get_season('team')
         logging.disable(logging.CRITICAL)
         try:
-            self.reg = create_reg(s, name="newPlayer")
+            self.reg = create_reg(s, name="Player1")
         finally:
             logging.disable(logging.NOTSET)
 
     @patch('heltour.tournament.lichessapi.get_user_meta',
-           return_value={"id":"newPlayer", "perfs":{"classical":{"games":25,"rating":2200,"prov":False}}})
+           return_value={"id":"Player1", "perfs":{"classical":{"games":25,"rating":2200,"prov":False}}})
     def test_validation_ok(self, user_meta):
         validate_registration(self.reg.id)
         # validate_registration does not change the object directly but updates it from a new query,
         # so for checks we have to as well
         reg = Registration.objects.get(pk=self.reg.id)
         self.assertTrue(user_meta.called)
-        self.assertEqual(user_meta.call_args[0], ('newPlayer', 1))
+        self.assertEqual(user_meta.call_args[0], ('Player1', 1))
         self.assertTrue(reg.has_played_20_games)
         self.assertTrue(reg.validation_ok)
         self.assertFalse(reg.validation_warning)
 
     @patch('heltour.tournament.lichessapi.get_user_meta',
-           return_value={"id":"newPlayer", "perfs":{"classical":{"games":25,"rating":2200,"prov":True}}})
+           return_value={"id":"Player1", "perfs":{"classical":{"games":25,"rating":2200,"prov":True}}})
     def test_validation_prov(self, user_meta):
         validate_registration(self.reg.id)
         reg = Registration.objects.get(pk=self.reg.id)

--- a/heltour/tournament/tests/test_views.py
+++ b/heltour/tournament/tests/test_views.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import timedelta
 from django.test import TestCase, override_settings
 from django.utils import timezone
@@ -9,7 +8,7 @@ from heltour.tournament.models import (League, Player, Round, Season, Team,
         TeamPairing, TeamPlayerPairing, LonePlayerPairing)
 from heltour.tournament.tests.testutils import (createCommonLeagueData,
         create_reg, get_league, get_season, league_url, reverse, season_tag,
-        season_url)
+        season_url, Shush)
 from heltour.tournament.views import _get_league, _get_season
 
 
@@ -83,11 +82,8 @@ class RostersTestCase(TestCase):
         self.assertTemplateUsed(response, 'tournament/team_rosters.html')
 
         # triggering a 404 writes to the log, disable that temporarily for nicer test output
-        logging.disable(logging.CRITICAL)
-        try:
+        with Shush():
             response = self.client.get(season_url('lone', 'rosters'))
-        finally:
-            logging.disable(logging.NOTSET)
         self.assertEqual(404, response.status_code)
 
 
@@ -110,13 +106,9 @@ class CrosstableTestCase(TestCase):
     def test_template(self):
         response = self.client.get(season_url('team', 'crosstable'))
         self.assertTemplateUsed(response, 'tournament/team_crosstable.html')
-
         # triggering a 404 writes to the log, disable that temporarily for nicer test output
-        logging.disable(logging.CRITICAL)
-        try:
+        with Shush():
             response = self.client.get(season_url('lone', 'crosstable'))
-        finally:
-            logging.disable(logging.NOTSET)
         self.assertEqual(404, response.status_code)
 
 
@@ -126,11 +118,8 @@ class WallchartTestCase(TestCase):
 
     def test_template(self):
         # triggering a 404 writes to the log, disable that temporarily for nicer test output
-        logging.disable(logging.CRITICAL)
-        try:
+        with Shush():
             response = self.client.get(season_url('team', 'wallchart'))
-        finally:
-            logging.disable(logging.NOTSET)
         self.assertEqual(404, response.status_code)
 
         response = self.client.get(season_url('lone', 'wallchart'))

--- a/heltour/tournament/tests/test_workflows.py
+++ b/heltour/tournament/tests/test_workflows.py
@@ -1,8 +1,7 @@
-import logging
 from django.test import TestCase
 from heltour.tournament.models import Player
 from heltour.tournament.workflows import ApproveRegistrationWorkflow
-from heltour.tournament.tests.testutils import createCommonLeagueData, create_reg, get_season, set_rating
+from heltour.tournament.tests.testutils import createCommonLeagueData, create_reg, get_season, set_rating, Shush
 
 
 class TestLJPCase(TestCase):
@@ -13,11 +12,8 @@ class TestLJPCase(TestCase):
         new_player = Player.objects.create(lichess_username="newplayer", profile={"perfs": {"bullet": {"games": 50, "rating": 1650, "rd": 45, "prog": 10}}})
         season = get_season("lone")
         # creating a reg writes to the log, disable that temporarily for nicer test output
-        logging.disable(logging.CRITICAL)
-        try:
+        with Shush():
             reg = create_reg(season, "newplayer")
-        finally:
-            logging.disable(logging.NOTSET)
         arw = ApproveRegistrationWorkflow(reg, 4)
         self.assertEqual(arw.default_byes, 2)
         self.assertEqual(arw.active_round_count, 3)

--- a/heltour/tournament/tests/testutils.py
+++ b/heltour/tournament/tests/testutils.py
@@ -1,3 +1,4 @@
+import logging
 from heltour.tournament.models import (League, LonePlayerScore, Player, Registration, Round,
                                        Season, SeasonPlayer, Team, TeamMember, TeamScore)
 from django.urls import reverse
@@ -74,3 +75,17 @@ def createCommonLeagueData(round_count=3):
             LonePlayerScore.objects.create(season_player=sp)
             player_num += 1
             TeamMember.objects.create(team=team, player=player, board_number=b)
+
+
+class Shush:
+    def __init__(self):
+        logging.disable(logging.CRITICAL)
+
+    def __enter__(self):
+        return(self)
+
+    def __exit__(self, type, value, traceback):
+        logging.disable(logging.NOTSET)
+        if type is not None:
+            logging.getLogger(__name__).error(f"Error {type}: {value}")
+        return True


### PR DESCRIPTION
1. fix a bug where reg validations still expected there to be the "are you on slack" question on the form.
2. add test cases for validation
3. fix a small bug with missing brackets in the notifications to mods
4. fix a small bug where ApiWorkerError and ApiClientError were caught in such an order, that ApiClientErrors were always caught by the ApiWorkerError already
5. add and use a context manager for disabling logging in tests
6. fix tests that added registrations without an existing player (not possible anymore, because registering requires login, and login adds a player if it does not exist)
