### PR TITLE
fix the edit_rosters css

### DIFF
--- a/heltour/tournament/static/tournament/css/_admin_edit_rosters.scss
+++ b/heltour/tournament/static/tournament/css/_admin_edit_rosters.scss
@@ -10,9 +10,9 @@
     #table-edit-rosters tr th:last-child,
     #table-alternates tr th:last-child,
     #table-unassigned tr th:last-child,
-    #table-edit-rosters tr th:nth-last-child(2),
-    #table-alternates tr th:nth-last-child(2),
-    #table-unassigned tr th:nth-last-child(2) {
+    #table-edit-rosters tr th:nth-last-child(1),
+    #table-alternates tr th:nth-last-child(1),
+    #table-unassigned tr th:nth-last-child(1) {
         width: 55px;
     }
 

--- a/heltour/tournament/templates/tournament/admin/edit_rosters.html
+++ b/heltour/tournament/templates/tournament/admin/edit_rosters.html
@@ -110,7 +110,6 @@
                     <th>Board {{ board_number }}</th>
                 {% endfor %}
                 <th>&nbsp;</th>
-                <th>&nbsp;</th>
             </tr>
             </thead>
             <tbody>
@@ -138,7 +137,6 @@
                     </td>
                 {% endfor %}
                 <td></td>
-                <td></td>
             </tr>
             </tbody>
         </table>
@@ -151,7 +149,6 @@
                 {% for board_number in board_numbers %}
                     <th>&nbsp;</th>
                 {% endfor %}
-                <th>&nbsp;</th>
                 <th>&nbsp;</th>
             </tr>
             </thead>
@@ -179,7 +176,6 @@
                         </table>
                     </td>
                 {% endfor %}
-                <td></td>
                 <td></td>
             </tr>
             </tbody>


### PR DESCRIPTION
also remove the empty columns for alternates and unassigned players; and fix the css so only the last column is more narrow, not the last two.