### PR TITLE
change some testing settings

### DIFF
--- a/heltour/settings_default.py
+++ b/heltour/settings_default.py
@@ -38,7 +38,6 @@ ALLOWED_HOSTS = [
     'heltour.lakin.ca',
     'heltour.lakin.ca',
     'localhost',
-    'testserver',
 ]
 CSRF_TRUSTED_ORIGINS = [
     'https://www.lichess4545.tv',

--- a/heltour/settings_testing.py
+++ b/heltour/settings_testing.py
@@ -9,3 +9,16 @@ STORAGES = {
             'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage'
         },
 }
+
+# use a faster hasher for tests
+PASSWORD_HASHERS = [
+        "django.contrib.auth.hashers.MD5PasswordHasher"
+]
+
+# using sqlite3 in memory speeds up tests
+#DATABASES = {
+#    'default': {
+#        'ENGINE': 'django.db.backends.sqlite3',
+#        'NAME': ':memory:',
+#    }
+#}

--- a/heltour/settings_testing.py
+++ b/heltour/settings_testing.py
@@ -22,3 +22,36 @@ PASSWORD_HASHERS = [
 #        'NAME': ':memory:',
 #    }
 #}
+
+# we do not need debug toolbar for testing
+INSTALLED_APPS = [
+    'cacheops',
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'django.contrib.sites',
+    'heltour.%s' % HELTOUR_APP,
+    'reversion',
+    'bootstrap3',
+    'ckeditor',
+    'ckeditor_uploader',
+    'django_comments',
+    'heltour.comments',
+    'static_precompiler',
+    'impersonate',
+]
+
+# remove some middleware for tests
+MIDDLEWARE = [
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+]
+
+ALLOWED_HOSTS = [
+    'testserver',
+]

--- a/heltour/tournament/tasks.py
+++ b/heltour/tournament/tasks.py
@@ -35,7 +35,6 @@ def to_usernames(users: UsernamesQuerySet):
 def just_username(qs: QuerySet[Player]) -> UsernamesQuerySet:
     return qs \
         .order_by('lichess_username') \
-        .distinct('lichess_username') \
         .values('lichess_username')
 
 def active_player_usernames() -> List[str]:

--- a/heltour/tournament/tests/test_views.py
+++ b/heltour/tournament/tests/test_views.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.utils import timezone
 from django.contrib.auth.models import User
 from django.http.response import Http404
@@ -138,7 +138,6 @@ class TemplatesRedirectTestCase(TestCase):
         response = self.client.get(season_url('lone', 'stats'))
         self.assertTemplateUsed(response, 'tournament/lone_stats.html')
 
-@override_settings(PASSWORD_HASHERS=["django.contrib.auth.hashers.MD5PasswordHasher"])
 class RegisterTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
and ADDITIONALLY, remove a `distinct` from from `just_usernames()` in tasks.py. that distinct should not matter, because lichess_usernames are unique anyway (or at least they should be), and are set as unique in #657. we only use this function for two querysets, and both of them could not have duplicated lichess_usernames as they are only filtered down `Player.objects.all()` sets.

* always use a faster password hasher in tests (though we mostly don't hash our passwords anyway)
* use "testserver" as an allowed host in testing settings only, remove it from default settings.
* cut some middleware, including the debug toolbar.
* since the debug toolbar complains about not being in the middleware, remove it from installed apps for tests as well.
* add some commented-out code to switch to a sqlite in-memory data base. i'm not suggesting we always use a different data base for testing – but on my old machine this speeds up testing by about 50%, so i would like to have it easily available. not opposed to having it always enabled for tests, but i don't know enough about the differences between sqlite and postgres to understand whether that might lead to problems long term.

the latter thing is also the reason for disabling "distinct" above, since sqlite does not have support for that. as a side note, in the same function `just_username()` we order by the username, and i have no idea why that order would matter. it's quite plausible to me that this sorting could be removed as well.

finally, i understand that all of this smells like unnecessary optimisations, so i'm fine with none of it being merged.