### PR TITLE
Registration updates

### DIFF
--- a/heltour/tournament/models.py
+++ b/heltour/tournament/models.py
@@ -870,6 +870,17 @@ class Player(_BaseModel):
             self.profile = user_meta
         self.save()
 
+    def profile_update_after(self) -> datetime:
+        # lichess gives us "seenAt" in miliseconds as the last time the user was online
+        # thus, the profile was last updated *after* this seenAt.
+        if self.profile is None:
+            return None
+        seenAt = self.profile.get('seenAt')
+        if seenAt is None:
+            return None
+        else:
+            return datetime.utcfromtimestamp(seenAt / 1000)
+
     @classmethod
     def get_or_create(cls, lichess_username):
         player, _ = Player.objects.get_or_create(lichess_username__iexact=lichess_username,

--- a/heltour/tournament/models.py
+++ b/heltour/tournament/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import logging
 import re
 from collections import defaultdict, namedtuple
-from datetime import date, timedelta
+from datetime import datetime, timedelta
 
 import reversion
 from ckeditor_uploader.fields import RichTextUploadingField
@@ -873,13 +873,10 @@ class Player(_BaseModel):
     def profile_update_after(self) -> datetime:
         # lichess gives us "seenAt" in miliseconds as the last time the user was online
         # thus, the profile was last updated *after* this seenAt.
-        if self.profile is None:
-            return None
-        seenAt = self.profile.get('seenAt')
-        if seenAt is None:
-            return None
-        else:
+        seenAt = (self.profile or {}) .get('seenAt')
+        if seenAt is not None:
             return datetime.utcfromtimestamp(seenAt / 1000)
+        return None
 
     @classmethod
     def get_or_create(cls, lichess_username):

--- a/heltour/tournament/tasks.py
+++ b/heltour/tournament/tasks.py
@@ -68,22 +68,27 @@ def active_player_usernames() -> List[str]:
     active_qs = players_qs.filter(seasonplayer__season__is_completed=False)
     return to_usernames(just_username(active_qs))
 
-def not_updated_recently_usernames(active_usernames: List[str]) -> List[str]:
-    players_qs = Player.objects.all()
-    total_players = players_qs.count()
+def active_registrations_usernames(without_usernames: List[str]) -> List[str]:
+    active_regs = just_username(
+        Registration.objects.filter(
+            status__exact="pending", season__registration_open=True
+        ).exclude(lichess_username__in=without_usernames)
+    )
     _24_hours = timezone.now() - timedelta(hours=24)
-    qs = players_qs \
-            .filter(date_modified__lte=_24_hours) \
-            .exclude(lichess_username__in=active_usernames)
-
-    one_24th = total_players/24 # update them approximately every 24 hours
-    return to_usernames(just_username(qs)[:one_24th])
+    reg_players = Player.objects.filter(
+        lichess_username__in=active_regs, date_modified__lte=_24_hours
+    ) # TODO: simplify this once Player is a foreign key of Registration
+    total_players = reg_players.count()
+    one_24th = total_players / 24  # update them approximately every 24 hours
+    return to_usernames(just_username(reg_players)[:one_24th])
 
 @app.task()
 def update_player_ratings():
     active_players = active_player_usernames()
-    not_updated_recently = not_updated_recently_usernames(active_players)
-    usernames = active_players + not_updated_recently
+    registered_players = active_registrations_usernames(
+        without_usernames=active_players
+    )
+    usernames = active_players + registered_players
     logger.info(f"[START] Updating {len(usernames)} player ratings")
     updated = 0
     try:

--- a/heltour/tournament/tests/test_tasks.py
+++ b/heltour/tournament/tests/test_tasks.py
@@ -318,7 +318,7 @@ class TestTeamChannel(TestCase):
     @classmethod
     def setUpTestData(cls):
         createCommonLeagueData()
-        cls.team_ids = Team.objects.all().values("pk")
+        cls.team_ids = Team.objects.all().order_by("pk").values("pk")
 
     @patch(
         "heltour.tournament.slackapi.create_group",

--- a/heltour/tournament/tests/test_tasks.py
+++ b/heltour/tournament/tests/test_tasks.py
@@ -16,7 +16,6 @@ from heltour.tournament.models import (
 from heltour.tournament.tasks import (
     active_player_usernames,
     create_team_channel,
-    not_updated_recently_usernames,
     start_games,
     update_player_ratings,
     validate_registration,
@@ -44,8 +43,6 @@ class TestHelpers(TestCase):
         self.assertEqual(
             active_player_usernames(), self.playernames
         )  # names are Player1, ..., Player8
-        self.assertEqual(not_updated_recently_usernames(self.playernames), [])
-        # could mock.patch timezone.now to change what "recently" means for more tests
 
     def test_username_duplicates(self):
         SeasonPlayer.objects.create(

--- a/heltour/tournament/tests/test_views.py
+++ b/heltour/tournament/tests/test_views.py
@@ -190,7 +190,14 @@ class RegisterTestCase(TestCase):
             response, league_url("team", "login"), fetch_redirect_response=False
         )
 
-    def test_template(self):
+    @patch(
+        "heltour.tournament.lichessapi.get_user_meta",
+        return_value={
+            "perfs": {"classical": {"games": 25, "rating": 2200}},
+            "seenAt": 1621045384147,
+        },
+    )
+    def test_template(self, user_meta):
         self.client.login(username="Player1", password="test")
         response = self.client.get(season_url("team", "register"))
         self.assertTemplateUsed(response, "tournament/registration_closed.html")
@@ -201,6 +208,7 @@ class RegisterTestCase(TestCase):
 
         response = self.client.get(season_url("team", "register"))
         self.assertTemplateUsed(response, "tournament/register.html")
+        self.assertTrue(user_meta.called)
 
         response = self.client.get(season_url("team", "registration_success"))
         self.assertTemplateUsed(response, "tournament/registration_success.html")

--- a/heltour/tournament/tests/test_views.py
+++ b/heltour/tournament/tests/test_views.py
@@ -190,14 +190,7 @@ class RegisterTestCase(TestCase):
             response, league_url("team", "login"), fetch_redirect_response=False
         )
 
-    @patch(
-        "heltour.tournament.lichessapi.get_user_meta",
-        return_value={
-            "perfs": {"classical": {"games": 25, "rating": 2200}},
-            "seenAt": 1621045384147,
-        },
-    )
-    def test_template(self, user_meta):
+    def test_template(self):
         self.client.login(username="Player1", password="test")
         response = self.client.get(season_url("team", "register"))
         self.assertTemplateUsed(response, "tournament/registration_closed.html")
@@ -208,7 +201,6 @@ class RegisterTestCase(TestCase):
 
         response = self.client.get(season_url("team", "register"))
         self.assertTemplateUsed(response, "tournament/register.html")
-        self.assertTrue(user_meta.called)
 
         response = self.client.get(season_url("team", "registration_success"))
         self.assertTemplateUsed(response, "tournament/registration_success.html")

--- a/heltour/tournament/views.py
+++ b/heltour/tournament/views.py
@@ -805,7 +805,6 @@ class RegisterView(LoginRequiredMixin, LeagueView):
                                               season_tag=self.season.tag))
             else:
                 player = Player.get_or_create(self.request.user.username)
-
                 rules_doc = LeagueDocument.objects.filter(league=self.league, type='rules').first()
                 if rules_doc is not None:
                     doc_url = reverse('by_league:document', args=[self.league.tag, rules_doc.tag])


### PR DESCRIPTION
get started on #673:
* stop fetching profiles of inactive players
* fetch profiles of registered players instead
* add a function "profile_update_after" to `Player`, that converts the lichess timestamp 'seenAt' to a datetime. could alternatively save the timestamp when we updated last.
* use that new function to decide whether a player profile needs updating when a player goes to the registration page
* if it does need updating, fetch the profile from lichess
* fix tests that now fail
* lint some of the files touched