### PR TITLE
remove seasonal active_players pages

### DIFF
--- a/heltour/tournament/templates/base.html
+++ b/heltour/tournament/templates/base.html
@@ -101,7 +101,7 @@
                                 <li>
                                     <a href="{% leagueurl 'stats' league.tag season.tag %}">Stats</a>
                                 </li>
-                                <li><a href="{% leagueurl 'active_players' league.tag season.tag %}">Active Players</a></li>
+                                <li><a href="{% leagueurl 'active_players' league.tag %}">Active Players</a></li>
                             </ul>
                         </li>
                     {% endif %}

--- a/heltour/tournament/templates/tournament/active_players.html
+++ b/heltour/tournament/templates/tournament/active_players.html
@@ -42,13 +42,13 @@
                 <div class="pagination">
                     <span class="step-links">
                         {% if page_obj.has_previous %}
-                            <a href="{% leagueurl 'active_players' league.tag season.tag %}">&laquo; first</a> |
-                            <a href="{% leagueurl 'active_players' league.tag season.tag %}{{ page_obj.previous_page_number }}">previous</a> |
+                            <a href="{% leagueurl 'active_players' league.tag %}">&laquo; first</a> |
+                            <a href="{% leagueurl 'active_players' league.tag %}{{ page_obj.previous_page_number }}">previous</a> |
                         {% endif %}
                         <span class="current">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
                         {% if page_obj.has_next %}
-                            | <a href="{% leagueurl 'active_players' league.tag season.tag %}{{ page_obj.next_page_number }}">next</a> |
-                            <a href="{% leagueurl 'active_players' league.tag season.tag %}{{ page_obj.paginator.num_pages }}">last &raquo;</a>
+                            | <a href="{% leagueurl 'active_players' league.tag %}{{ page_obj.next_page_number }}">next</a> |
+                            <a href="{% leagueurl 'active_players' league.tag %}{{ page_obj.paginator.num_pages }}">last &raquo;</a>
                         {% endif %}
                     </span>
                 </div>

--- a/heltour/tournament/urls.py
+++ b/heltour/tournament/urls.py
@@ -126,15 +126,6 @@ season_urlpatterns = [
         name="alternate_decline",
     ),
     path("notifications/", views.NotificationsView.as_view(), name="notifications"),
-    path("active_players/",
-         views.ActivePlayerTableView.as_view(),
-         name="active_players"
-    ),
-    path(
-        "active_players/<int:page>/",
-        views.ActivePlayerTableView.as_view(),
-        name="active_players"
-    ),
 ]
 
 league_urlpatterns = [
@@ -157,6 +148,15 @@ league_urlpatterns = [
         "login/<slug:secret_token>/", views.LoginView.as_view(), name="login_with_token"
     ),
     path("logout/", views.LogoutView.as_view(), name="logout"),
+    path("active_players/",
+         views.ActivePlayerTableView.as_view(),
+         name="active_players"
+    ),
+    path(
+        "active_players/<int:page>/",
+        views.ActivePlayerTableView.as_view(),
+        name="active_players"
+    ),
 ]
 
 api_urlpatterns = [


### PR DESCRIPTION
404 on seasonal active_player pages, menu links directly to per league version.