### PR TITLE
remove imports unused after emails are not sent on registration anymore

### DIFF
--- a/heltour/tournament/views.py
+++ b/heltour/tournament/views.py
@@ -4,7 +4,6 @@ import math
 import re
 from collections import defaultdict, namedtuple
 from datetime import timedelta
-from smtplib import SMTPException
 
 import reversion
 from cacheops.query import cached_as
@@ -12,14 +11,12 @@ from django.conf import settings
 from django.contrib.auth import logout
 from django.core.cache import cache
 from django.core.exceptions import SuspiciousOperation
-from django.core.mail import send_mail
 from django.core.mail.message import EmailMessage
 from django.core.paginator import Paginator
 from django.db.models import Count
 from django.db.models.query import Prefetch
 from django.http.response import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
-from django.template.loader import render_to_string
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
 from django.utils.http import url_has_allowed_host_and_scheme


### PR DESCRIPTION
it's kind of telling that this was the only place in views.py that sent emails too.