### PR TITLE
630 api tests

### DIFF
--- a/heltour/tournament/api.py
+++ b/heltour/tournament/api.py
@@ -148,20 +148,20 @@ def update_pairing(request):
     except ValueError:
         return HttpResponse("Bad request", status=400)
 
-    rounds = _get_active_rounds(league_tag, season_tag)
+    rounds = _get_active_rounds(league_tag=league_tag, season_tag=season_tag)
     if len(rounds) == 0:
         return JsonResponse({"updated": 0, "error": "no_matching_rounds"})
 
     pairings = []
     for r in rounds:
-        pairings += _get_pairings(r, None, white, black)
+        pairings += _get_pairings(round_=r, player=None, white=white, black=black)
 
     reversed = False
     if len(pairings) == 0:
         # Try alternate colors
         reversed = True
         for r in rounds:
-            pairings += list(_get_pairings(r, None, black, white))
+            pairings += list(_get_pairings(round_=r, player=None, white=black, black=white))
 
     if len(pairings) == 0:
         return JsonResponse({"updated": 0, "error": "not_found"})

--- a/heltour/tournament/api.py
+++ b/heltour/tournament/api.py
@@ -67,18 +67,30 @@ def find_pairing(request):
     except ValueError:
         return HttpResponse("Bad request", status=400)
 
-    rounds = _get_active_rounds(league_tag, season_tag)
+    rounds = _get_active_rounds(league_tag=league_tag, season_tag=season_tag)
     if len(rounds) == 0:
         return JsonResponse({"pairings": None, "error": "no_matching_rounds"})
 
     pairings = []
     for r in rounds:
-        pairings += list(_get_pairings(r, player, white, black, scheduled))
+        pairings += list(
+            _get_pairings(
+                round_=r, player=player, white=white, black=black, scheduled=scheduled
+            )
+        )
 
     if len(pairings) == 0:
         # Try alternate colors
         for r in rounds:
-            pairings += list(_get_pairings(r, player, black, white, scheduled))
+            pairings += list(
+                _get_pairings(
+                    round_=r,
+                    player=player,
+                    white=black,
+                    black=white,
+                    scheduled=scheduled,
+                )
+            )
 
     league = League.objects.filter(tag=league_tag).first()
     return JsonResponse({"pairings": [_export_pairing(p, league) for p in pairings]})

--- a/heltour/tournament/tests/test_api.py
+++ b/heltour/tournament/tests/test_api.py
@@ -1,33 +1,145 @@
 import json
+from unittest.mock import patch
 
-from django.test import TestCase, Client
-from heltour.tournament.models import *
+from django.test import TestCase, RequestFactory
+from django.utils import timezone
+
+from heltour.tournament.api import (
+    _filter_pairings,
+    _get_active_rounds,
+    _get_next_round,
+    _get_pairings,
+    find_pairing,
+)
+from heltour.tournament.models import (
+    ApiKey,
+    LonePlayerPairing,
+    Player,
+    Round,
+    Season,
+)
+from heltour.tournament.tests.testutils import (
+    createCommonLeagueData,
+    get_round,
+    get_season,
+)
 
 
-def createCommonAPIData():
-    team_count = 4
-    round_count = 3
-    board_count = 2
-
-    league = League.objects.create(name='Team League', tag='team', competitor_type='team')
-    season = Season.objects.create(league=league, name='Team Season', tag='team',
-                                   rounds=round_count, boards=board_count)
-    league2 = League.objects.create(name='Lone League', tag='lone')
-    season2 = Season.objects.create(league=league2, name='Lone Season', tag='lone',
-                                    rounds=round_count, boards=board_count)
-
-    player_num = 1
-    for n in range(1, team_count + 1):
-        team = Team.objects.create(season=season, number=n, name='Team %s' % n)
-        TeamScore.objects.create(team=team)
-        for b in range(1, board_count + 1):
-            player = Player.objects.create(lichess_username='Player%d' % player_num)
-            player_num += 1
-            TeamMember.objects.create(team=team, player=player, board_number=b)
-
-
-class _ApiTestsBase(TestCase):
+class ApiPairingsTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.api_key = ApiKey.objects.create(name='test_key')
-        cls.client = Client(HTTP_AUTHORIZATION="Token {}".format(cls.api_key.secret_token))
+        createCommonLeagueData()
+        s = get_season("lone")
+        Season.objects.filter(pk=s.pk).update(
+            is_active=True
+        )
+        cls.r1 = get_round(league_type="lone", round_number=1)
+        Round.objects.filter(pk=cls.r1.pk).update(publish_pairings=True)
+        p1 = Player.objects.get(lichess_username="Player1")
+        p2 = Player.objects.get(lichess_username="Player2")
+        p3 = Player.objects.get(lichess_username="Player3")
+        p4 = Player.objects.get(lichess_username="Player4")
+        cls.lp1 = LonePlayerPairing.objects.create(
+            round=cls.r1, white=p1, black=p2, pairing_order=1
+        )
+        cls.lp2 = LonePlayerPairing.objects.create(
+            round=cls.r1,
+            white=p3,
+            black=p4,
+            pairing_order=2,
+            scheduled_time=timezone.now(),
+        )
+        cls.api_key = ApiKey.objects.create(name="test_key")
+        cls.lp = LonePlayerPairing.objects.all()
+        cls.lp1_list = list(cls.lp.filter(pk=cls.lp1.pk))
+        cls.lp2_list = list(cls.lp.filter(pk=cls.lp2.pk))
+        cls.rf = RequestFactory()
+
+    def test_filter_pairings(self):
+        f_none = _filter_pairings(pairings=self.lp)
+        self.assertEqual(f_none, list(self.lp))
+        f_player_player1 = _filter_pairings(pairings=self.lp, player="Player1")
+        self.assertEqual(f_player_player1, self.lp1_list)
+        f_white_player3 = _filter_pairings(pairings=self.lp, white="Player3")
+        self.assertEqual(f_white_player3, self.lp2_list)
+        f_black_player2 = _filter_pairings(pairings=self.lp, black="Player2")
+        self.assertEqual(f_black_player2, self.lp1_list)
+        f_scheduled_true = _filter_pairings(pairings=self.lp, scheduled=True)
+        self.assertEqual(f_scheduled_true, self.lp2_list)
+        f_scheduled_false = _filter_pairings(pairings=self.lp, scheduled=False)
+        self.assertEqual(f_scheduled_false, self.lp1_list)
+
+    def test_get_pairings(self):
+        f_none = _get_pairings(round_=self.r1)
+        self.assertEqual(f_none, list(self.lp))
+        f_player_player4 = _get_pairings(round_=self.r1, player="Player4")
+        self.assertEqual(f_player_player4, self.lp2_list)
+        f_white_player1 = _get_pairings(round_=self.r1, white="Player1")
+        self.assertEqual(f_white_player1, self.lp1_list)
+        f_black_player2 = _get_pairings(round_=self.r1, black="Player2")
+        self.assertEqual(f_black_player2, self.lp1_list)
+        f_scheduled_true = _get_pairings(round_=self.r1, scheduled=True)
+        self.assertEqual(f_scheduled_true, self.lp2_list)
+        f_scheduled_false = _get_pairings(round_=self.r1, scheduled=False)
+        self.assertEqual(f_scheduled_false, self.lp1_list)
+
+    def test_get_next_round(self):
+        next_r = _get_next_round(
+            league_tag="loneleague", season_tag="loneseason", round_num=1
+        )
+        self.assertEqual(next_r, self.r1)
+        next_r_round_num_none = _get_next_round(
+            league_tag="loneleague", season_tag="loneseason", round_num=None
+        )
+        self.assertEqual(next_r_round_num_none, self.r1)
+        next_r_league_none = _get_next_round(
+            league_tag=None, season_tag="loneseason", round_num=1
+        )
+        self.assertEqual(next_r_league_none, self.r1)
+        next_r_season_none = _get_next_round(
+            league_tag="loneleague", season_tag=None, round_num=1
+        )
+        self.assertEqual(next_r_season_none, self.r1)
+
+    def test_get_active_rounds(self):
+        act_r = _get_active_rounds(league_tag=None, season_tag=None)
+        self.assertEqual(act_r.first(), self.r1)
+        act_r_league = _get_active_rounds(league_tag="loneleague", season_tag=None)
+        self.assertEqual(act_r_league.first(), self.r1)
+        act_r_season = _get_active_rounds(season_tag="loneseason", league_tag=None)
+        self.assertEqual(act_r_season.first(), self.r1)
+
+    @patch("heltour.tournament.api._get_active_rounds")
+    @patch("heltour.tournament.api._get_pairings")
+    def test_find_pairing(self, pairings, rounds):
+        rounds.return_value = Round.objects.filter(pk=self.r1.pk)
+        pairings.return_value = list(self.lp)
+        req = self.rf.get(
+                path="/api/find_pairing/",
+                query_params={
+                    "league": "loneleague",
+                },
+                headers={"AUTHORIZATION": f"Token {self.api_key.secret_token}"}
+            )
+        pairings_json = find_pairing(req)
+        self.assertTrue(pairings.called)
+        self.assertEqual(pairings.call_args.kwargs["round_"], self.r1)
+        self.assertEqual(pairings.call_args.kwargs["scheduled"], None)
+        self.assertEqual(pairings_json.status_code, 200)
+        try:
+            pairings = json.loads(pairings_json.content)
+            pairing1white = pairings["pairings"][0]["white"]
+            pairing1black = pairings["pairings"][0]["black"]
+            pairing2white = pairings["pairings"][1]["white"]
+            pairing2black = pairings["pairings"][1]["black"]
+        except json.JSONDecodeError:
+            pairing1white = "JSON error not decoded"
+        except KeyError:
+            pairing1white = "Key 'pairings', 'white' or 'black' not in JSON"
+        except IndexError:
+            pairing1white = "Not enough pairings found"
+        self.assertEqual(pairing1white, "Player1")
+        self.assertEqual(pairing1black, "Player2")
+        self.assertEqual(pairing2white, "Player3")
+        self.assertEqual(pairing2black, "Player4")
+

--- a/heltour/tournament/tests/test_api.py
+++ b/heltour/tournament/tests/test_api.py
@@ -166,8 +166,8 @@ class ApiPairingsTestCase(TestCase):
             self.assertEqual(pairing2white, "Player3")
             self.assertEqual(pairing2black, "Player4")
         except json.JSONDecodeError as e:
-            logger.error("JSON not decoded:", e)
+            logger.error(f"JSON not decoded:\n{e}")
         except KeyError as e:
-            logger.error("Key 'pairings', 'white' or 'black' not in JSON: ", e)
+            logger.error(f"Expected key not in JSON:\n{e}")
         except IndexError as e:
-            logger.error("Not enough pairings found: ", e)
+            logger.error(f"Not enough pairings found:\n{e}")

--- a/heltour/tournament/tests/testutils.py
+++ b/heltour/tournament/tests/testutils.py
@@ -46,7 +46,7 @@ def get_player(player_name):
     return Player.objects.get(lichess_username__iexact=player_name)
 
 
-def get_round(league_type, round_number):
+def get_round(league_type: str, round_number: int) -> Round:
     return Round.objects.get(season=get_season(league_type), number=round_number)
 
 def get_team(team_name: str) -> Team:


### PR DESCRIPTION
* tests for api.py, so we can in the future avoid trivial bugs in `update_pairings` and friends.
* some small changes in api.py, so some functions are called with kwargs instead of args.
* lazily add typing to `get_round()` in testutils.py