### PR TITLE
Fix channel creation tests

### DIFF
--- a/heltour/tournament/tasks.py
+++ b/heltour/tournament/tasks.py
@@ -722,6 +722,7 @@ def create_team_channel(team_ids: List[int]) -> None:
             - <{pairings_url}|View your team pairings>
             - <{calendar_url}|Import your team pairings to your calendar>""")
 
+    # note: the order_by("pk") below is necessary to make the order reproducible so tests do not fail
     for team in Team.objects.filter(id__in=team_ids).order_by("pk").select_related('season__league').nocache():
         pairings_url = abs_url(reverse('by_league:by_season:pairings_by_team',
                                        args=[team.season.league.tag, team.season.tag, team.number]))

--- a/heltour/tournament/tasks.py
+++ b/heltour/tournament/tasks.py
@@ -712,7 +712,7 @@ def do_notify_slack_link(lichess_username, **kwargs):
 
 
 @app.task()
-def create_team_channel(team_ids):
+def create_team_channel(team_ids: List[int]) -> None:
     intro_message = textwrap.dedent("""
             Welcome! This is your private team channel. Feel free to chat, study, discuss strategy, or whatever you like!
             You need to pick a team captain and a team name by {season_start}.
@@ -722,7 +722,7 @@ def create_team_channel(team_ids):
             - <{pairings_url}|View your team pairings>
             - <{calendar_url}|Import your team pairings to your calendar>""")
 
-    for team in Team.objects.filter(id__in=team_ids).select_related('season__league').nocache():
+    for team in Team.objects.filter(id__in=team_ids).order_by("pk").select_related('season__league').nocache():
         pairings_url = abs_url(reverse('by_league:by_season:pairings_by_team',
                                        args=[team.season.league.tag, team.season.tag, team.number]))
         calendar_url = abs_url(reverse('by_league:by_season:pairings_by_team_icalendar',

--- a/heltour/tournament/tasks.py
+++ b/heltour/tournament/tasks.py
@@ -722,8 +722,13 @@ def create_team_channel(team_ids: List[int]) -> None:
             - <{pairings_url}|View your team pairings>
             - <{calendar_url}|Import your team pairings to your calendar>""")
 
-    # note: the order_by("pk") below is necessary to make the order reproducible so tests do not fail
-    for team in Team.objects.filter(id__in=team_ids).order_by("pk").select_related('season__league').nocache():
+    # note: the order_by("pk") below is necessary to make the order reproducible so tests do not randomly fail
+    for team in (
+        Team.objects.filter(id__in=team_ids)
+        .order_by("pk")
+        .select_related("season__league")
+        .nocache()
+    ):
         pairings_url = abs_url(reverse('by_league:by_season:pairings_by_team',
                                        args=[team.season.league.tag, team.season.tag, team.number]))
         calendar_url = abs_url(reverse('by_league:by_season:pairings_by_team_icalendar',


### PR DESCRIPTION
we previously fixed failing team creation tests by forcing an order of team channels in the tests. that made failing tests less likely, but failures still occur because the task itself does not use ordered teams. change this to force the same order.
in fairness, it would probably be better to improve the test conditions. but this is easier.

while at it, lazily add some typing to the task function.