### PR TITLE
specify lichess4545 in the user-agent

### DIFF
--- a/heltour/api_worker/urls.py
+++ b/heltour/api_worker/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+
 from heltour.api_worker import views
 
 urlpatterns = [

--- a/heltour/api_worker/worker.py
+++ b/heltour/api_worker/worker.py
@@ -1,10 +1,11 @@
+import json
 import queue
 import threading
-import websocket
-import json
 import time
-from django.utils import timezone
 from datetime import timedelta
+
+import websocket
+from django.utils import timezone
 
 
 def _run_worker():

--- a/heltour/settings_default.py
+++ b/heltour/settings_default.py
@@ -55,6 +55,8 @@ if 'HELTOUR_APP' in os.environ and os.environ['HELTOUR_APP'] == 'API_WORKER':
 else:
     HELTOUR_APP = 'tournament'
 
+HELTOUR_VERSION: str = "1.0.1"
+
 INSTALLED_APPS = [
     'cacheops',
     'django.contrib.admin',


### PR DESCRIPTION
be more specific about who we are in the user-agent.
not sure if the heltour version is already specified anywhere, i put it into the settings. though i have found some information that it could go into `manage.py` as `__version__`, but it seems to me it would be more difficult to find there.

edit: also let ruff re-sort all the imports in `heltour/api_worker/`

edit 2: not sure if a user-agent should be sent in the websocket connection in `worker.py` as well.