### PR TITLE
change autostart strings to not use 'confirm'

### DIFF
--- a/heltour/tournament/notify.py
+++ b/heltour/tournament/notify.py
@@ -634,14 +634,17 @@ def notify_players_game_scheduled(round_, pairing, **kwargs):
 
     time_part = (
         f"Your game has been scheduled for {pairing.scheduled_time:%A, %H:%M UTC}."
-        "\nYou can confirm that time"
+        "\nYou can agree to the game being started automatically on lichess at that time"
+    )
+    condition_part = (
+        "The game will only be started automatically "
+        "if your opponent agrees to it as well."
     )
     confirm_url = abs_url(reverse("by_league:confirm_scheduled_time", args=[league.tag]))
-    im_msg = f"{time_part} <{confirm_url}|here>."
+    im_msg = f"{time_part} <{confirm_url}|here>. {condition_part}"
 
     li_subject = f"Round {round_} - {league}"
-    li_msg = f"{time_part}here: {confirm_url}"
-
+    li_msg = f"{time_part} here: {confirm_url} - {condition_part}"
     send_pairing_notification(
         type_="game_scheduled",
         pairing=pairing,

--- a/heltour/tournament/templates/tournament/confirm_scheduled_time.html
+++ b/heltour/tournament/templates/tournament/confirm_scheduled_time.html
@@ -6,11 +6,11 @@
         <div class="col-md-12">
             <div class="well">
                 <div class="well-head">
-                    <h3>Confirm Scheduling</h3>
+                    <h3>Agree to starting game automatically</h3>
                 </div>
                 <div class="well-body">
                     <p>
-                        <b>By confirming, you allow us to start the game as well as your clock.</b> The game will be started a couple of minutes before the scheduled time, the clock will start at the scheduled time or a couple minutes later. <b>We don't take responsibility for any bugs resulting in rating loss.</b> But we don't think that there are any bugs right now. That is why the feature is enabled.
+                        <b>By agreeing, you allow us to start the game as well as your clock.</b> The game will be started a couple of minutes before the scheduled time, the clock will start at the scheduled time or a couple minutes later. <b>We don't take responsibility for any bugs resulting in rating loss.</b> But we don't think that there are any bugs right now. That is why the feature is enabled.
                     </p>
                     <p>
                         If there is any problem with the scheduled time, please contact your opponent. Retracting does not change the scheduled time, it only prevents us from starting the game for you.
@@ -18,7 +18,7 @@
                 </div>
                 <div class="well">
                     <div class="well-head">
-                        <h3>Confirm Playing Time</h3>
+                        <h3>Agree to automatic game start</h3>
                     </div>
                     <div class="well-body">
                         <table class="my-pairings">
@@ -42,9 +42,9 @@
                                                                 type="submit"
                                                                 class="btn btn-primary">
                                                             {% if pairing.white == player and not pairing.white_confirmed %}
-                                                                Confirm
+                                                                Agree
                                                             {% elif pairing.black == player and not pairing.black_confirmed %}
-                                                                Confirm
+                                                                Agree
                                                             {% else %}
                                                                 Retract
                                                             {% endif %}


### PR DESCRIPTION
to conform with what league moderators want.